### PR TITLE
This fixes #211, fixes #160

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,5 +18,8 @@
 # For static build
 /build
 
+# Test results
+/results
+
 # For packaging
 plv8-*.zip

--- a/.travis.yml
+++ b/.travis.yml
@@ -47,6 +47,7 @@ before_script:
 env:
   matrix:
     - PGVERSION=9.5 v8=5.4.500.43
+    - PGVERSION=9.5 v8=4.4.63.31
     - PGVERSION=9.4 v8=5.4.500.43
     - PGVERSION=9.3 v8=5.4.500.43
     - PGVERSION=9.2 v8=5.4.500.43

--- a/.travis.yml
+++ b/.travis.yml
@@ -48,13 +48,13 @@ before_script:
 env:
   matrix:
     - PGVERSION=9.5 v8=4.4.63.31
-    - PGVERSION=9.5 v8=5.8.301
+    - PGVERSION=9.5 v8=5.4.500.43
     - PGVERSION=9.4 v8=4.4.63.31
-    - PGVERSION=9.4 v8=5.8.301
+    - PGVERSION=9.4 v8=5.4.500.43
     - PGVERSION=9.3 v8=4.4.63.31
-    - PGVERSION=9.3 v8=5.8.301
+    - PGVERSION=9.3 v8=5.4.500.43
     - PGVERSION=9.2 v8=4.4.63.31
-    - PGVERSION=9.2 v8=5.8.301
+    - PGVERSION=9.2 v8=5.4.500.43
 
 
 language: cpp

--- a/.travis.yml
+++ b/.travis.yml
@@ -32,14 +32,13 @@ before_script:
   - fetch v8; cd v8
   - git checkout $v8 && gclient sync > /dev/null
   - git describe --always
-  - make dependencies > /dev/null || true
   - export CXX=clang++
   - export LD=clang++
   - make native library=shared -j8 werror=no snapshot=off i18nsupport=off
   - sudo cp -rf include/* /usr/include
   - sudo cp -rf include /usr/include
   - sudo install -v out/native/d8 /usr/bin/
-  - sudo install out/native/*.a /usr/lib
+  - sudo install -v out/native/obj.target/src/*.a /usr/lib
   - popd
   - createuser -U postgres -s travis
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -38,22 +38,17 @@ before_script:
   - make native library=shared -j8 werror=no snapshot=off i18nsupport=off
   - sudo cp -rf include/* /usr/include
   - sudo cp -rf include /usr/include
-  - sudo install -v --mode=0644 out/native/lib.target/* /usr/lib
   - sudo install -v out/native/d8 /usr/bin/
-  - sudo install out/native/obj.target/tools/gyp/*.a /usr/lib
+  - sudo install out/native/*.a /usr/lib
   - popd
   - createuser -U postgres -s travis
 
 
 env:
   matrix:
-    - PGVERSION=9.5 v8=4.4.63.31
     - PGVERSION=9.5 v8=5.4.500.43
-    - PGVERSION=9.4 v8=4.4.63.31
     - PGVERSION=9.4 v8=5.4.500.43
-    - PGVERSION=9.3 v8=4.4.63.31
     - PGVERSION=9.3 v8=5.4.500.43
-    - PGVERSION=9.2 v8=4.4.63.31
     - PGVERSION=9.2 v8=5.4.500.43
 
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -48,13 +48,13 @@ before_script:
 env:
   matrix:
     - PGVERSION=9.5 v8=4.4.63.31
-    - PGVERSION=9.5 v8=5.1.281.14
+    - PGVERSION=9.5 v8=5.8.301
     - PGVERSION=9.4 v8=4.4.63.31
-    - PGVERSION=9.4 v8=5.1.281.14
+    - PGVERSION=9.4 v8=5.8.301
     - PGVERSION=9.3 v8=4.4.63.31
-    - PGVERSION=9.3 v8=5.1.281.14
+    - PGVERSION=9.3 v8=5.8.301
     - PGVERSION=9.2 v8=4.4.63.31
-    - PGVERSION=9.2 v8=5.1.281.14
+    - PGVERSION=9.2 v8=5.8.301
 
 
 language: cpp

--- a/.travis.yml
+++ b/.travis.yml
@@ -39,6 +39,7 @@ before_script:
   - sudo cp -rf include /usr/include
   - sudo install -v out/native/d8 /usr/bin/
   - sudo install -v out/native/obj.target/src/*.a /usr/lib
+  - sudo install -v out/native/obj.target/src/*.so /usr/lib
   - popd
   - createuser -U postgres -s travis
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -47,7 +47,6 @@ before_script:
 env:
   matrix:
     - PGVERSION=9.5 v8=5.4.500.43
-    - PGVERSION=9.5 v8=4.4.63.31
     - PGVERSION=9.4 v8=5.4.500.43
     - PGVERSION=9.3 v8=5.4.500.43
     - PGVERSION=9.2 v8=5.4.500.43

--- a/META.json
+++ b/META.json
@@ -2,7 +2,7 @@
     "name": "plv8",
     "abstract": "A procedural language in JavaScript powered by V8",
     "description": "plv8 is a trusted procedural language that is safe to use, fast to run and easy to develop.",
-    "version": "2.0.2",
+    "version": "2.0.3-dev",
     "maintainer": [
         "Jerry Sievert <code@legitimatesounding.com>"
     ],
@@ -23,21 +23,21 @@
     },
     "provides": {
         "plv8": {
-            "file": "plv8--2.0.2.sql",
+            "file": "plv8--2.0.3-dev.sql",
             "docfile": "doc/plv8.md",
-            "version": "2.0.1",
+            "version": "2.0.3-dev",
             "abstract": "A procedural language in JavaScript"
          },
         "plcoffee": {
-            "file": "plcoffee--2.0.2.sql",
+            "file": "plcoffee--2.0.3-dev.sql",
             "docfile": "doc/plv8.md",
-            "version": "2.0.1",
+            "version": "2.0.3-dev",
             "abstract": "A procedural language in CoffeeScript"
          },
         "plls": {
-            "file": "plls--2.0.2.sql",
+            "file": "plls--2.0.3-dev.sql",
             "docfile": "doc/plv8.md",
-            "version": "2.0.1",
+            "version": "2.0.3-dev",
             "abstract": "A procedural language in LiveScript"
          }
     },

--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,7 @@
 #   'make static' will download v8 and build, then statically link to it.
 #
 #-----------------------------------------------------------------------------#
-PLV8_VERSION = 2.0.2
+PLV8_VERSION = 2.0.3-dev
 
 PG_CONFIG = pg_config
 PGXS := $(shell $(PG_CONFIG) --pgxs)
@@ -30,6 +30,7 @@ OBJS = $(SRCS:.cc=.o)
 MODULE_big = plv8
 EXTENSION = plv8
 PLV8_DATA = plv8.control plv8--$(PLV8_VERSION).sql
+
 DATA = $(PLV8_DATA)
 ifndef DISABLE_DIALECT
 DATA += plcoffee.control plcoffee--$(PLV8_VERSION).sql \

--- a/Makefile.v8
+++ b/Makefile.v8
@@ -7,7 +7,7 @@
 # structure in v8 which may be different from version to another, but user
 # can specify the v8 version by AUTOV8_VERSION, too.
 #-----------------------------------------------------------------------------#
-AUTOV8_VERSION = 5.8.301
+AUTOV8_VERSION = 5.4.500.43
 AUTOV8_DIR = build/v8-git-mirror-$(AUTOV8_VERSION)
 AUTOV8_OUT = build/v8-git-mirror-$(AUTOV8_VERSION)/out/native
 AUTOV8_DEPOT_TOOLS = build/depot_tools
@@ -35,7 +35,7 @@ $(AUTOV8_OUT)/third_party/icu/common/icudtb.dat:
 $(AUTOV8_OUT)/third_party/icu/common/icudtl.dat:
 
 $(AUTOV8_LIB): $(AUTOV8_DIR)
-	env CXXFLAGS=-fPIC CFLAGS=-fPIC $(MAKE) -C build/v8-git-mirror-$(AUTOV8_VERSION) x64.debug -j 4
+	env CXXFLAGS=-fPIC CFLAGS=-fPIC $(MAKE) -C build/v8-git-mirror-$(AUTOV8_VERSION) native
 	test -f $(AUTOV8_OUT)/libv8_base.a || \
 		ln -s $(abspath $(AUTOV8_OUT)/obj.target/src/libv8_base.a) \
 			$(AUTOV8_OUT)/libv8_base.a

--- a/Makefile.v8
+++ b/Makefile.v8
@@ -7,13 +7,12 @@
 # structure in v8 which may be different from version to another, but user
 # can specify the v8 version by AUTOV8_VERSION, too.
 #-----------------------------------------------------------------------------#
-AUTOV8_VERSION = 5.4.500.43
+AUTOV8_VERSION = 5.8.301
 AUTOV8_DIR = build/v8-git-mirror-$(AUTOV8_VERSION)
 AUTOV8_OUT = build/v8-git-mirror-$(AUTOV8_VERSION)/out/native
 AUTOV8_DEPOT_TOOLS = build/depot_tools
 AUTOV8_LIB = $(AUTOV8_OUT)/libv8_snapshot.a
 AUTOV8_STATIC_LIBS = libv8_base.a libv8_nosnapshot.a libv8_libplatform.a libv8_libbase.a libv8_libsampler.a libicui18n.a libicuuc.a
-
 export PATH := $(abspath $(AUTOV8_DEPOT_TOOLS)):$(PATH)
 
 SHLIB_LINK += $(addprefix $(AUTOV8_OUT)/, $(AUTOV8_STATIC_LIBS))
@@ -31,8 +30,12 @@ $(AUTOV8_DIR): $(AUTOV8_DEPOT_TOOLS)
 	cd build; fetch v8; cd v8; git checkout $(AUTOV8_VERSION); gclient sync
 	mv build/v8 $(AUTOV8_DIR)
 
+$(AUTOV8_OUT)/third_party/icu/common/icudtb.dat:
+
+$(AUTOV8_OUT)/third_party/icu/common/icudtl.dat:
+
 $(AUTOV8_LIB): $(AUTOV8_DIR)
-	env CXXFLAGS=-fPIC CFLAGS=-fPIC $(MAKE) -C build/v8-git-mirror-$(AUTOV8_VERSION) native
+	env CXXFLAGS=-fPIC CFLAGS=-fPIC $(MAKE) -C build/v8-git-mirror-$(AUTOV8_VERSION) x64.debug -j 4
 	test -f $(AUTOV8_OUT)/libv8_base.a || \
 		ln -s $(abspath $(AUTOV8_OUT)/obj.target/src/libv8_base.a) \
 			$(AUTOV8_OUT)/libv8_base.a

--- a/contrib/README.md
+++ b/contrib/README.md
@@ -1,0 +1,16 @@
+# Contributed files
+
+## ICU
+
+Data files for ICU's i18n support when compiling with `make static`.  Copy one
+of the files, depending on your platform, and set the `plv8.icu_data` variable
+in `postgresql.conf`.
+
+* icudtl.dat - Little Endian architectures (Intel)
+* icudtb.dat - Big Endian architectures (Sparc)
+
+For ARM, you will need to figure out which Endianess your hardware and OS is
+configured for.
+
+NOTE: it is important that the user that Postgres is started with has read
+access to the file.

--- a/contrib/icu/icudtb.dat
+++ b/contrib/icu/icudtb.dat
@@ -1,0 +1,1 @@
+/Users/jerry/work/plv8/build/v8-git-mirror-5.8.301/third_party/icu/common/icudtb.dat

--- a/contrib/icu/icudtl.dat
+++ b/contrib/icu/icudtl.dat
@@ -1,0 +1,1 @@
+/Users/jerry/work/plv8/build/v8-git-mirror-5.8.301/third_party/icu/common/icudtl.dat

--- a/doc/plv8.md
+++ b/doc/plv8.md
@@ -93,14 +93,6 @@ https://github.com/plv8/plv8/issues/29
   SHLIB_LINK := $(SHLIB_LINK) -lv8 -Wl,-Bstatic -lstdc++ -Wl,-Bdynamic -lm
 ```
 
-### Test the Build
-PL/v8 supports installcheck test.  Make sure to set `custom_variable_classes = 'plv8'`
-in your postgresql.conf (before 9.2) and run:
-
-```
-$ make installcheck
-```
-
 ### Installing the build:
 After running `make` or `make static` the following files must be copied to the
 correct location for PostgreSQL to find them:
@@ -130,6 +122,14 @@ $ make install
 
 > Note: If you need to install PL/v8 for a different version of PostgreSQL, pass
 the `PG_CONFIG` variable. See above.
+
+### Test the Install
+PL/v8 supports installcheck test.  Make sure to set `custom_variable_classes = 'plv8'`
+in your postgresql.conf (before 9.2) and run:
+
+```
+$ make installcheck
+```
 
 ### Debian/Ubuntu 14.04 and 16.04:
 You can install PL/v8 using `apt-get`, but it will be version `v1.4.8`

--- a/doc/plv8.md
+++ b/doc/plv8.md
@@ -41,12 +41,14 @@ are building those from source.
 
 ### Build from source:
 Determine the [PL/v8 release](https://github.com/plv8/plv8/releases) you want to download and use it's version and path below.
-```shell
+
+```
 $ wget https://github.com/plv8/plv8/archive/v2.0.0.tar.gz
 $ tar -xvzf v2.0.0.tar.gz
 $ cd plv8-2.0.0
 $ make static
 ```
+
 This will build PL/v8 for you linking to Google's v8 as a static library by
 downloading the v8 source at a specific version and building it along with
 PL/v8. The build will be for the highest PostgreSQL version you have installed
@@ -69,20 +71,23 @@ installed. If you need to build PL/v8 for PostgreSQL 9.5 while you have 9.6
 installed pass `make` the `PG_CONFIG` variable to your 9.5 version of
 `pg_config`. This works for `make`, `make static`, `make install`. For example
 in Ubuntu:
-```shell
+
+```
 $ make PG_CONFIG=/usr/lib/postgresql/9.5/bin/pg_config
 ```
 
 > Note: You may run into problems with your C++ complier version. You can pass
 `make` the `CUSTOM_CC` variable to change the complier. For example, to use
 `g++` version 4.9:
-```shell
+
+```
 $ make CUSTOM_CC g++-4.9
 ```
 
 > Note: In `mingw64`, you may have difficulty in building PL/v8. If so, try to
 make the following changes in Makefile. For more detail, please refer to
 https://github.com/plv8/plv8/issues/29
+
 ```
   CUSTOM_CC = gcc
   SHLIB_LINK := $(SHLIB_LINK) -lv8 -Wl,-Bstatic -lstdc++ -Wl,-Bdynamic -lm
@@ -91,7 +96,8 @@ https://github.com/plv8/plv8/issues/29
 ### Test the Build
 PL/v8 supports installcheck test.  Make sure to set `custom_variable_classes = 'plv8'`
 in your postgresql.conf (before 9.2) and run:
-```shell
+
+```
 $ make installcheck
 ```
 
@@ -115,7 +121,8 @@ need the CoffeeScript or LiveScript versions:
 
 ### Automatically Install the Build
 You can install the build for your system by running:
-```shell
+
+```
 $ make install
 ```
 
@@ -127,7 +134,8 @@ the `PG_CONFIG` variable. See above.
 ### Debian/Ubuntu 14.04 and 16.04:
 You can install PL/v8 using `apt-get`, but it will be version `v1.4.8`
 (As of 2016-12-16).
-```shell
+
+```
 $ apt-get install postgresql-{your-postgresql-version-here}-plv8
 # e.g.
 $ apt-get install postgresql-9.1-plv8
@@ -139,7 +147,8 @@ $ apt-get install postgresql-9.6-plv8
 TODO - PL/v8 supports Redhat/CentOS. A Pull Request for installation steps is greatly appreciated.
 
 ### MacOS:
-```shell
+
+```
 $ brew install plv8
 ```
 
@@ -151,7 +160,8 @@ Once the PL/v8 extensions have been added to the server, you should restart the
 PostgreSQL service. Then you can connect to the server and install the extensions
 on a database by running the following SQL queries on PostgreSQL version 9.1 or
 later:
-```sql
+
+```
   CREATE EXTENSION plv8;
   CREATE EXTENSION plls;
   CREATE EXTENSION plcoffee;
@@ -161,25 +171,30 @@ Make sure to set `custom_variable_classes = 'plv8'` in your `postgresql.conf` fi
 for PostgreSQL versions before 9.2.
 
 In the versions prior to 9.1 run the following to create database objects:
-```shell
+
+```
 $ psql -f plv8.sql
 ```
 
 ### Testing PL/v8 on a database:
 Below are some example queries to test if the extension is working:
-```sql
+
+```
   DO $$
-    plv8.elog(WARNING, 'plv8.version = ' + plv8.version); -- Will output the PL/v8 installed as a PostgreSQL `WARNING`.
+    plv8.elog(WARNING, 'plv8.version = ' + plv8.version); // Will output the PL/v8 installed as a PostgreSQL `WARNING`.
   $$ LANGUAGE plv8;
 ```
+
 As of 2.0.0, there is a function to determine which version of PL/v8 you have
 installed:
-```sql
+
+```
   SELECT plv8_version();
 ```
 
 #### JavaScript Example
-```sql
+
+```
   CREATE OR REPLACE FUNCTION plv8_test(keys text[], vals text[])
   RETURNS text AS $$
     var o = {};
@@ -197,7 +212,8 @@ installed:
 ```
 
 #### CoffeeScript Example
-```sql
+
+```
   CREATE OR REPLACE FUNCTION plcoffee_test(keys text[], vals text[])
   RETURNS text AS $$
     return JSON.stringify(keys.reduce(((o, key, idx) ->
@@ -212,7 +228,8 @@ installed:
 ```
 
 #### LiveScript Example
-```sql
+
+```
   CREATE OR REPLACE FUNCTION plls_test(keys text[], vals text[])
   RETURNS text AS $$
     return JSON.stringify { [key, vals[idx]] for key, idx in keys }
@@ -229,7 +246,8 @@ installed:
 In PL/v8, you can write your SQL invoked function in JavaScript. Use the usual
 `CREATE FUNCTION` statement with a JS function body. Here is an example of a
 scalar function call.
-```sql
+
+```
   CREATE FUNCTION plv8_test(keys text[], vals text[]) RETURNS text AS $$
       var o = {};
       for(var i=0; i<keys.length; i++){
@@ -258,7 +276,8 @@ or they will be named as `$1`, `$2` if the names are omitted.
 
 ## Set returning function calls
 PL/v8 supports `SET` returning function calls.
-```sql
+
+```
   CREATE TYPE rec AS (i integer, t text);
   CREATE FUNCTION set_of_records() RETURNS SETOF rec AS
   $$
@@ -293,7 +312,8 @@ If the argument object has extra properties that are not defined by the argument
 
 ## Trigger function calls
 PL/v8 supports trigger function calls.
-```sql
+
+```
   CREATE FUNCTION test_trigger() RETURNS trigger AS
   $$
       plv8.elog(NOTICE, "NEW = ", JSON.stringify(NEW));
@@ -334,7 +354,8 @@ For each variable semantics, see the [trigger section in PostgreSQL manual](http
 
 ## Inline statement calls
 PL/v8 supports `DO` block with PostgreSQL 9.0 and above.
-```sql
+
+```
   DO $$ plv8.elog(NOTICE, 'this', 'is', 'inline', 'code') $$ LANGUAGE plv8;
 ```
 
@@ -371,7 +392,8 @@ argument that replaces `$n` placeholders in `sql`. For `SELECT` queries, the
 returned value is an array of objects. Each hash represents each record.
 Column names are mapped to object properties. For non-SELECT commands, the
 returned value is an integer that represents number of affected rows.
-```sql
+
+```
   var json_result = plv8.execute( 'SELECT * FROM tbl' );
   var num_affected = plv8.execute( 'DELETE FROM tbl WHERE price > $1', [ 1000 ] );
 ```
@@ -383,7 +405,8 @@ Opens a prepared statement. The `typename` parameter is an array where
 each element is a string to indicate database type name for bind parameters.
 Returned value is an object of `PreparedPlan`. This object must be freed by
 `plan.free()` before leaving the function.
-```sql
+
+```
   var plan = plv8.prepare( 'SELECT * FROM tbl WHERE col = $1', ['int'] );
   var rows = plan.execute( [1] );
   var sum = 0;
@@ -405,7 +428,8 @@ Opens a cursor from the prepared statement. The `args` parameter is as
 `plv8.execute()`, and can be omitted if the statement does not have parameters
 at all. The returned object is of `Cursor`. This must be closed by `Cursor.close()`
 before leaving the function.
-```sql
+
+```
   var plan = plv8.prepare( 'SELECT * FROM tbl WHERE col = $1', ['int'] );
   var cursor = plan.cursor( [1] );
   var sum = 0, row;
@@ -438,11 +462,12 @@ Closes the cursor.
 `plv8.execute()` creates a subtransaction every time. If you need an atomic
 operation, you will need to call `plv8.subtransaction()` to create a subtransaction
 block.
-```sql
+
+```
     try{
       plv8.subtransaction(function(){
-        plv8.execute("INSERT INTO tbl VALUES(1)"); -- should be rolled back!
-        plv8.execute("INSERT INTO tbl VALUES(1/0)"); -- occurs an exception
+        plv8.execute("INSERT INTO tbl VALUES(1)"); // should be rolled back!
+        plv8.execute("INSERT INTO tbl VALUES(1/0)"); // occurs an exception
       });
     } catch(e) {
       ... do fall back plan ...
@@ -482,7 +507,8 @@ with the same name.
 
 In addition, PL/v8 provides a function to access other `plv8` functions that have
 been registered in the database.
-```sql
+
+```
     CREATE FUNCTION callee(a int) RETURNS int AS $$ return a * a $$ LANGUAGE plv8;
     CREATE FUNCTION caller(a int, t int) RETURNS int AS $$
       var func = plv8.find_function("callee");
@@ -570,7 +596,8 @@ the regular one. For these typed arrays, only 1-dimensional array without `NULL`
 element. Also, there is currently no way to create such typed array inside
 PL/v8 functions. Only arguments can be typed array. You can modify the element
 and return the value. An example for these types are as follows.
-```sql
+
+```
   CREATE FUNCTION int4sum(ary plv8_int4array) RETURNS int8 AS $$
     var sum = 0;
     for (var i = 0; i < ary.length; i++) {
@@ -618,7 +645,8 @@ object.
 ## Start-up procedure
 PL/v8 provides a start up facility, which allows you to call a `plv8` runtime
 environment initialization function specified in the `GUC` variable.
-```sql
+
+```
   SET plv8.start_proc = 'plv8_init';
   SELECT plv8_test(10);
 ```
@@ -651,7 +679,7 @@ extension and conversely removes them upon uninstallation, i.e., whenever
 
 You can explore some of the objects that PL/v8 stores under PostgreSQL:
 
-```sql
+```
 SELECT lanname FROM pg_catalog.pg_language WHERE lanname = 'plv8';
 SELECT proname FROM pg_proc p WHERE p.proname LIKE 'plv8%';
 SELECT typname FROM pg_catalog.pg_type WHERE typname LIKE 'plv8%';
@@ -685,7 +713,7 @@ up.
 
 The best way of finding out which PL/v8 version you're running is by executing:
 
-```sql
+```
 DO $$ plv8.elog(WARNING, plv8.version) $$ LANGUAGE plv8;
 ```
 

--- a/expected/inline.out
+++ b/expected/inline.out
@@ -2,4 +2,4 @@ DO $$ plv8.elog(NOTICE, 'this', 'is', 'inline', 'code') $$ LANGUAGE plv8;
 NOTICE:  this is inline code
 DO $$ plv8.return_next(new Object());$$ LANGUAGE plv8;
 ERROR:  return_next called in context that cannot accept a set
-DETAIL:  undefined() LINE 1:  plv8.return_next(new Object());
+CONTEXT:  undefined() LINE 1:  plv8.return_next(new Object());

--- a/expected/plv8-errors.out
+++ b/expected/plv8-errors.out
@@ -1,7 +1,7 @@
 CREATE FUNCTION test_sql_error() RETURNS void AS $$ plv8.execute("ERROR") $$ LANGUAGE plv8;
 SELECT test_sql_error();
 ERROR:  syntax error at or near "ERROR"
-DETAIL:  test_sql_error() LINE 1:  plv8.execute("ERROR") 
+CONTEXT:  test_sql_error() LINE 1:  plv8.execute("ERROR") 
 CREATE FUNCTION catch_sql_error() RETURNS void AS $$
 try {
 	plv8.execute("throw SQL error");
@@ -84,7 +84,7 @@ plv8.subtransaction(function(){
 $$ LANGUAGE plv8;
 SELECT test_subtransaction_throw();
 ERROR:  division by zero
-DETAIL:  test_subtransaction_throw() LINE 2: plv8.subtransaction(function(){
+CONTEXT:  test_subtransaction_throw() LINE 2: plv8.subtransaction(function(){
 SELECT * FROM subtrant;
  a 
 ---
@@ -144,4 +144,4 @@ plv8.elog(NOTICE, "should not come here");
 $$ LANGUAGE plv8;
 SELECT catch_elog_error2();
 ERROR:  custom exception
-DETAIL:  catch_elog_error2() LINE 5:         throw 'custom exception';
+CONTEXT:  catch_elog_error2() LINE 5:         throw 'custom exception';

--- a/expected/plv8.out
+++ b/expected/plv8.out
@@ -222,7 +222,7 @@ $$
 LANGUAGE plv8;
 SELECT * FROM set_of_record_but_non_obj();
 ERROR:  argument must be an object
-DETAIL:  set_of_record_but_non_obj() LINE 2: 	plv8.return_next( "abc" );
+CONTEXT:  set_of_record_but_non_obj() LINE 2: 	plv8.return_next( "abc" );
 CREATE FUNCTION set_of_integers() RETURNS SETOF integer AS
 $$
 	plv8.return_next( 1 );
@@ -282,7 +282,7 @@ SELECT * FROM set_of_unnamed_records() AS x(a int);
 -- field names mismatch
 SELECT * FROM set_of_unnamed_records() AS x(a int, c int);
 ERROR:  field name / property name mismatch
-DETAIL:  set_of_unnamed_records() LINE 2:     plv8.return_next({"a": 1, "b": 2}); 
+CONTEXT:  set_of_unnamed_records() LINE 2:     plv8.return_next({"a": 1, "b": 2}); 
 -- name counts and values match
 SELECT * FROM set_of_unnamed_records() AS x(a int, b int);
  a | b 
@@ -368,7 +368,7 @@ NOTICE:  args = ABC
 WARNING:  warning
 INFO:  Error: ERROR
 ERROR:  invalid error level
-DETAIL:  test_elog() LINE 9: 	plv8.elog(21, 'FATAL is not allowed');
+CONTEXT:  test_elog() LINE 9: 	plv8.elog(21, 'FATAL is not allowed');
 -- execute()
 CREATE TABLE test_tbl (i integer, s text);
 CREATE FUNCTION test_sql() RETURNS integer AS
@@ -539,15 +539,15 @@ SELECT * FROM trig_table;
 -- ERRORS
 CREATE FUNCTION syntax_error() RETURNS text AS '@' LANGUAGE plv8;
 ERROR:  SyntaxError: Unexpected token ILLEGAL
-DETAIL:  syntax_error() LINE 1: @
+CONTEXT:  syntax_error() LINE 1: @
 CREATE FUNCTION reference_error() RETURNS text AS 'not_defined' LANGUAGE plv8;
 SELECT reference_error();
 ERROR:  ReferenceError: not_defined is not defined
-DETAIL:  reference_error() LINE 1: not_defined
+CONTEXT:  reference_error() LINE 1: not_defined
 CREATE FUNCTION throw() RETURNS void AS $$throw new Error("an error");$$ LANGUAGE plv8;
 SELECT throw();
 ERROR:  an error
-DETAIL:  throw() LINE 1: throw new Error("an error");
+CONTEXT:  throw() LINE 1: throw new Error("an error");
 -- SPI operations
 CREATE FUNCTION prep1() RETURNS void AS $$
 var plan = plv8.prepare("SELECT * FROM test_tbl");
@@ -662,10 +662,10 @@ SELECT caller(10, 2);
 
 SELECT caller(10, 3);
 ERROR:  javascript function is not found for "sqlf"
-DETAIL:  caller() LINE 8:     func = plv8.find_function("sqlf");
+CONTEXT:  caller() LINE 8:     func = plv8.find_function("sqlf");
 SELECT caller(10, 4);
 ERROR:  function "callee(int, int)" does not exist
-DETAIL:  caller() LINE 10:     func = plv8.find_function("callee(int, int)");
+CONTEXT:  caller() LINE 10:     func = plv8.find_function("callee(int, int)");
 SELECT caller(10, 5);
  caller 
 --------

--- a/expected/plv8.out
+++ b/expected/plv8.out
@@ -538,7 +538,7 @@ SELECT * FROM trig_table;
 
 -- ERRORS
 CREATE FUNCTION syntax_error() RETURNS text AS '@' LANGUAGE plv8;
-ERROR:  SyntaxError: Unexpected token ILLEGAL
+ERROR:  SyntaxError: Invalid or unexpected token
 CONTEXT:  syntax_error() LINE 1: @
 CREATE FUNCTION reference_error() RETURNS text AS 'not_defined' LANGUAGE plv8;
 SELECT reference_error();

--- a/expected/startup.out
+++ b/expected/startup.out
@@ -19,6 +19,6 @@ reset plv8.start_proc;
 -- should fail because of a reference error
 do $$ plv8.elog(NOTICE, 'foo = ' + foo) $$ language plv8;
 ERROR:  ReferenceError: foo is not defined
-CONTEXT:  undefined() LINE 1:  plv8.elog(NOTICE, 'foo = ' + foo)
+CONTEXT:  undefined() LINE 1:  plv8.elog(NOTICE, 'foo = ' + foo) 
 RESET ROLE;
 DROP ROLE someone_else;

--- a/expected/startup.out
+++ b/expected/startup.out
@@ -19,6 +19,6 @@ reset plv8.start_proc;
 -- should fail because of a reference error
 do $$ plv8.elog(NOTICE, 'foo = ' + foo) $$ language plv8;
 ERROR:  ReferenceError: foo is not defined
-DETAIL:  undefined() LINE 1:  plv8.elog(NOTICE, 'foo = ' + foo) 
+CONTEXT:  undefined() LINE 1:  plv8.elog(NOTICE, 'foo = ' + foo)
 RESET ROLE;
 DROP ROLE someone_else;

--- a/expected/window.out
+++ b/expected/window.out
@@ -353,10 +353,10 @@ CREATE FUNCTION bad_alloc(sz text) RETURNS void AS $$
 $$ LANGUAGE plv8 WINDOW;
 SELECT bad_alloc('5') OVER ();
 ERROR:  window local memory overflow
-DETAIL:  bad_alloc() LINE 5:   winobj.set_partition_local(context);
+CONTEXT:  bad_alloc() LINE 5:   winobj.set_partition_local(context);
 SELECT bad_alloc('not a number') OVER ();
 ERROR:  window local memory overflow
-DETAIL:  bad_alloc() LINE 5:   winobj.set_partition_local(context);
+CONTEXT:  bad_alloc() LINE 5:   winobj.set_partition_local(context);
 SELECT bad_alloc('1000') OVER (); -- not so bad
  bad_alloc 
 -----------
@@ -368,4 +368,4 @@ CREATE FUNCTION non_window() RETURNS void AS $$
 $$ LANGUAGE plv8;
 SELECT non_window();
 ERROR:  get_window_object called in wrong context
-DETAIL:  non_window() LINE 2:   var winobj = plv8.get_window_object();
+CONTEXT:  non_window() LINE 2:   var winobj = plv8.get_window_object();

--- a/plv8.cc
+++ b/plv8.cc
@@ -1749,7 +1749,6 @@ js_error::js_error(TryCatch &try_catch) throw()
 	HandleScope		handle_scope(plv8_isolate);
 	String::Utf8Value	exception(try_catch.Exception());
 	Handle<Message>		message = try_catch.Message();
-	Handle<v8::Object> 	err = try_catch.Exception()->ToObject();
 
 	m_msg = NULL;
 	m_code = 0;
@@ -1760,6 +1759,7 @@ js_error::js_error(TryCatch &try_catch) throw()
 	try
 	{
 		m_msg = ToCStringCopy(exception);
+		Handle<v8::Object> err = try_catch.Exception()->ToObject();
 		StringInfoData	detailStr;
 		StringInfoData	hintStr;
 		StringInfoData	contextStr;

--- a/plv8.cc
+++ b/plv8.cc
@@ -1731,47 +1731,96 @@ Converter::ToDatum(Handle<v8::Value> value, Tuplestorestate *tupstore)
 }
 
 js_error::js_error() throw()
-	: m_msg(NULL), m_detail(NULL)
+	: m_msg(NULL), m_code(0), m_detail(NULL), m_hint(NULL), m_context(NULL)
 {
 }
 
 js_error::js_error(const char *msg) throw()
 {
 	m_msg = pstrdup(msg);
+	m_code = 0;
 	m_detail = NULL;
+	m_hint = NULL;
+	m_context = NULL;
 }
 
 js_error::js_error(TryCatch &try_catch) throw()
 {
-	HandleScope			handle_scope(plv8_isolate);
+	HandleScope		handle_scope(plv8_isolate);
 	String::Utf8Value	exception(try_catch.Exception());
 	Handle<Message>		message = try_catch.Message();
+	Handle<v8::Object> 	err = try_catch.Exception()->ToObject();
 
 	m_msg = NULL;
+	m_code = 0;
 	m_detail = NULL;
+	m_hint = NULL;
+	m_context = NULL;
 
 	try
 	{
 		m_msg = ToCStringCopy(exception);
+		StringInfoData	detailStr;
+		StringInfoData	hintStr;
+		StringInfoData	contextStr;
+		initStringInfo(&detailStr);
+		initStringInfo(&hintStr);
+		initStringInfo(&contextStr);
+
+		if (!err.IsEmpty())
+                {
+			v8::Local<v8::Value> errCode = err->Get(String::NewFromUtf8(plv8_isolate, "code"));
+			if (!errCode->IsUndefined() && !errCode->IsNull())
+			{
+				int32_t code = errCode->Int32Value();
+				m_code = code;
+			}
+
+			v8::Local<v8::Value> errDetail = err->Get(String::NewFromUtf8(plv8_isolate, "detail"));
+			if (!errDetail->IsUndefined() && !errDetail->IsNull())
+			{
+				CString detail(errDetail);
+				appendStringInfo(&detailStr, "%s", detail.str("?"));
+				m_detail = detailStr.data;
+			}
+
+			v8::Local<v8::Value> errHint = err->Get(String::NewFromUtf8(plv8_isolate, "hint"));
+			if (!errHint->IsUndefined() && !errHint->IsNull())
+			{
+				CString hint(errHint);
+				appendStringInfo(&hintStr, "%s", hint.str("?"));
+				m_hint = hintStr.data;
+			}
+
+			v8::Local<v8::Value> errContext = err->Get(String::NewFromUtf8(plv8_isolate, "context"));
+			if (!errContext->IsUndefined() && !errContext->IsNull())
+			{
+				CString context(errContext);
+				appendStringInfo(&contextStr, "%s\n", context.str("?"));
+			}
+                }
+
 
 		if (!message.IsEmpty())
 		{
-			StringInfoData	str;
-			CString			script(message->GetScriptResourceName());
-			int				lineno = message->GetLineNumber();
-			CString			source(message->GetSourceLine());
+			CString		script(message->GetScriptResourceName());
+			int		lineno = message->GetLineNumber();
+			CString		source(message->GetSourceLine());
+			// TODO: Get stack trace?
+			//Handle<StackTrace> stackTrace(message->GetStackTrace());
 
 			/*
 			 * Report lineno - 1 because "function _(...){" was added
 			 * at the first line to the javascript code.
 			 */
-			initStringInfo(&str);
 			if (strstr(m_msg, "Error: ") == m_msg)
 				m_msg += 7;
-			appendStringInfo(&str, "%s() LINE %d: %s",
+
+			appendStringInfo(&contextStr, "%s() LINE %d: %s",
 				script.str("?"), lineno - 1, source.str("?"));
-			m_detail = str.data;
 		}
+
+		m_context = contextStr.data;
 	}
 	catch (...)
 	{
@@ -1798,8 +1847,13 @@ void
 js_error::rethrow() throw()
 {
 	ereport(ERROR,
-		(m_msg ? errmsg("%s", m_msg) : 0,
-			m_detail ? errdetail("%s", m_detail) : 0));
+		(
+			m_code ? errcode(m_code): 0,
+			m_msg ? errmsg("%s", m_msg) : 0,
+			m_detail ? errdetail("%s", m_detail) : 0,
+			m_hint ? errhint("%s", m_hint) : 0,
+			m_context ? errcontext("%s", m_context) : 0
+                ));
 	exit(0);	// keep compiler quiet
 }
 
@@ -1810,3 +1864,4 @@ pg_error::rethrow() throw()
 	PG_RE_THROW();
 	exit(0);	// keep compiler quiet
 }
+

--- a/plv8.h
+++ b/plv8.h
@@ -48,7 +48,10 @@ class js_error
 {
 private:
 	char	   *m_msg;
+	int	   m_code;
 	char	   *m_detail;
+	char	   *m_hint;
+	char	   *m_context;
 
 public:
 	js_error() throw();

--- a/plv8_func.cc
+++ b/plv8_func.cc
@@ -274,9 +274,18 @@ plv8_FunctionInvoker(const FunctionCallbackInfo<v8::Value> &args) throw()
 			Handle<Primitive>(ToString(edata->datatype_name)) : Null(plv8_isolate);
 		Handle<Primitive> constraint_name = edata->constraint_name ?
 			Handle<Primitive>(ToString(edata->constraint_name)) : Null(plv8_isolate);
+		Handle<Primitive> detail = edata->detail ?
+			Handle<Primitive>(ToString(edata->detail)) : Null(plv8_isolate);
+		Handle<Primitive> hint = edata->hint ?
+			Handle<Primitive>(ToString(edata->hint)) : Null(plv8_isolate);
+		Handle<Primitive> context = edata->context ?
+			Handle<Primitive>(ToString(edata->context)) : Null(plv8_isolate);
+		Handle<Primitive> internalquery = edata->internalquery ?
+			Handle<Primitive>(ToString(edata->internalquery)) : Null(plv8_isolate);
+		Handle<Integer> code = Uint32::New(plv8_isolate, edata->sqlerrcode);
+
 #endif
 
-		// XXX: add other fields? (detail, hint, context, internalquery...)
 		FlushErrorState();
 		FreeErrorData(edata);
 
@@ -288,6 +297,11 @@ plv8_FunctionInvoker(const FunctionCallbackInfo<v8::Value> &args) throw()
 		err->Set(String::NewFromUtf8(plv8_isolate, "column_name"), column_name);
 		err->Set(String::NewFromUtf8(plv8_isolate, "datatype_name"), datatype_name);
 		err->Set(String::NewFromUtf8(plv8_isolate, "constraint_name"), constraint_name);
+		err->Set(String::NewFromUtf8(plv8_isolate, "detail"), detail);
+		err->Set(String::NewFromUtf8(plv8_isolate, "hint"), hint);
+		err->Set(String::NewFromUtf8(plv8_isolate, "context"), context);
+		err->Set(String::NewFromUtf8(plv8_isolate, "internalquery"), internalquery);
+		err->Set(String::NewFromUtf8(plv8_isolate, "code"), code);
 #endif
 
 		args.GetReturnValue().Set(plv8_isolate->ThrowException(err));


### PR DESCRIPTION
Send full error messages: `CODE`, `DETAIL`, `HINT`, `CONTEXT`.
Use `CONTEXT` instead of `DETAIL`.
Return the correct `SQLERRCODE`.
Expose `detail`, `hint`, `context`, `internalquery` and `sqlerrcode` to JavaScript error catching.

Fixes #211 
Fixes #160 
Related to #117 

Raising an exception such as:
```sql
    RAISE EXCEPTION USING
      MESSAGE = 'A First Name is required.',
      DETAIL = 'A detailed message??',
      HINT = 'Do this to avoid that.',
      COLUMN = 'firstName'
      ;
```

The error object in a `try {} catch(err) {}` will now look like:
```json
{
  "code": 16777248,
  "column_name": "firstName",
  "constraint_name": null,
  "context": "PL/pgSQL function _callsanerror() line 5 at assignment\nSQL statement \"SELECT _callsanerror();\"",
  "datatype_name": null,
  "detail": "A detailed message??",
  "hint": "Do this to avoid that.",
  "internalquery": null,
  "message": "A First Name is required.",
  "schema_name": null,
  "sqlerrcode": "P0001",
  "table_name": null
}
```

The error reported from the example in #211:
```sql
DO $$
  plv8.execute("SELECT _callsanerror();");
$$ LANGUAGE plv8;
```
Is now:
```
ERROR:  An error!
DETAIL:  A detailed message??
HINT:  Do this to avoid that.
CONTEXT:  PL/pgSQL function _callsanerror() line 5 at assignment
SQL statement "SELECT _callsanerror();"
undefined() LINE 2:   plv8.execute("SELECT _callsanerror();");
********** Error **********

ERROR: An error!
SQL state: P0001
Detail: A detailed message??
Hint: Do this to avoid that.
Context: PL/pgSQL function _callsanerror() line 5 at assignment
SQL statement "SELECT _callsanerror();"
undefined() LINE 2:   plv8.execute("SELECT _callsanerror();");
```
Matching the `plpgsql` version.