### PR TITLE
check tools; restartable build

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,7 @@
 # Generic build files
 *.o
 *.so
+docker-build*.out
 
 # For static build
 /build
@@ -44,3 +45,8 @@ plv8-*.zip
 /windows/_CPack_Packages
 /windows/install_manifest.txt
 /windows/plv8*.zip
+
+# emacs
+[#]*
+.[#]*
+*~

--- a/.travis.yml
+++ b/.travis.yml
@@ -28,11 +28,8 @@ before_script:
 
 env:
   matrix:
-    - PGVERSION=9.6
-    - PGVERSION=9.4
-    - PGVERSION=9.2
-
-
+    - PGVERSION=11.2
+    - PGVERSION=10.7
 
 language: cpp
 compiler:

--- a/.travis.yml
+++ b/.travis.yml
@@ -28,8 +28,9 @@ before_script:
 
 env:
   matrix:
-    - PGVERSION=11.2
-    - PGVERSION=10.7
+    - PGVERSION=11
+    - PGVERSION=10
+
 
 language: cpp
 compiler:

--- a/.travis.yml
+++ b/.travis.yml
@@ -25,12 +25,11 @@ before_script:
   - gcc -v
   - createuser -U postgres -s travis
 
-
 env:
   matrix:
     - PGVERSION=11
     - PGVERSION=10
-
+    - PGVERSION=9.6
 
 language: cpp
 compiler:

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,39 @@
+# use docker build --build-arg PG_VERSION=xxx to support other versions of postgres,
+# e.g. older pg versions, different OS distros, etc.
+ARG PG_VERSION=11
+FROM postgres:$PG_VERSION
+
+# use docker build --build-arg PLV8_VERSION=xxx to support older versions of plv8
+ARG PLV8_VERSION=2.3.9
+
+RUN buildDependencies="build-essential \
+    ca-certificates \
+    python \
+    curl \
+    git-core \
+    pkg-config \
+    libc++-dev \
+    libc++abi-dev \
+    postgresql-server-dev-$PG_MAJOR" \
+  && apt-get update \
+  && apt-get install -y --no-install-recommends ${buildDependencies} \
+  && mkdir -p /tmp/build \
+  && echo "https://github.com/plv8/plv8/archive/v$PLV8_VERSION.tar.gz" \
+  && curl -o /tmp/build/plv8-$PLV8_VERSION.tar.gz -SL "https://github.com/plv8/plv8/archive/v$PLV8_VERSION.tar.gz" \
+  && cd /tmp/build \
+  && tar -xzf /tmp/build/plv8-$PLV8_VERSION.tar.gz -C /tmp/build/ \
+  && cd /tmp/build/plv8-$PLV8_VERSION \
+  && make static \
+  && make install \
+  && strip /usr/lib/postgresql/${PG_MAJOR}/lib/plv8-$PLV8_VERSION.so \
+  && cd / \
+  && apt-get clean \
+  && apt-get remove -y  ${buildDependencies} \
+  && apt-get autoremove -y \
+  && rm -rf /tmp/build /var/lib/apt/lists/*
+
+# note: based on an older Dockerfile from https://github.com/shady77/plv8-docker/
+LABEL maintainer "plv8.docker@gmail.com"
+LABEL plv8_version $PLV8_VERSION
+LABEL postgres_version $PG_VERSION
+LABEL postgres_major_version ${PG_MAJOR}

--- a/Makefile
+++ b/Makefile
@@ -8,11 +8,16 @@
 # can specify the v8 version by AUTOV8_VERSION, too.
 #-----------------------------------------------------------------------------#
 AUTOV8_VERSION = 7.0.276.20
-AUTOV8_DIR = build/v8
-AUTOV8_OUT = build/v8/out.gn/x64.release/obj
-AUTOV8_DEPOT_TOOLS = build/depot_tools
+
+# https://stackoverflow.com/a/23324703
+ROOT_DIR:=$(shell dirname $(realpath $(lastword $(MAKEFILE_LIST))))
+BUILD_DIR = $(ROOT_DIR)/build
+AUTOV8_DIR = $(BUILD_DIR)/v8
+AUTOV8_OUT = $(BUILD_DIR)/v8/out.gn/x64.release/obj
+AUTOV8_DEPOT_TOOLS = $(BUILD_DIR)/depot_tools
 AUTOV8_LIB = $(AUTOV8_OUT)/libv8_snapshot.a
 AUTOV8_STATIC_LIBS = -lv8_base -lv8_snapshot -lv8_libplatform -lv8_libbase -lv8_libsampler
+
 export PATH := $(abspath $(AUTOV8_DEPOT_TOOLS)):$(PATH)
 
 SHLIB_LINK += -L$(AUTOV8_OUT) -L$(AUTOV8_OUT)/third_party/icu $(AUTOV8_STATIC_LIBS)
@@ -22,7 +27,7 @@ ifndef USE_ICU
 	V8_OPTIONS += v8_enable_i18n_support=false
 endif
 
-all: v8
+all: check-tools v8
 
 # For some reason, this solves parallel make dependency.
 plv8_config.h plv8.so: v8
@@ -30,15 +35,35 @@ plv8_config.h plv8.so: v8
 $(AUTOV8_DEPOT_TOOLS):
 	mkdir -p build
 	cd build; git clone https://chromium.googlesource.com/chromium/tools/depot_tools.git
+	rm -fr $(BUILD_DIR)/.gclient   # so fetch is clean
 
-$(AUTOV8_DIR): $(AUTOV8_DEPOT_TOOLS)
-	cd build; fetch v8; cd v8; git checkout $(AUTOV8_VERSION); gclient sync ; tools/dev/v8gen.py $(PLATFORM) -- $(V8_OPTIONS)
+$(BUILD_DIR)/autov8_fetched: $(AUTOV8_DEPOT_TOOLS)
+	rm -fr $(AUTOV8_DIR) $(BUILD_DIR)/.gclient
+	cd $(BUILD_DIR); fetch $(notdir $(AUTOV8_DIR)) && \
+		rm -f $(BUILD_DIR)/autov8_fetched; echo $(shell date) > $(BUILD_DIR)/autov8_fetched
+
+$(BUILD_DIR)/autov8_gitcheckedout: $(BUILD_DIR)/autov8_fetched
+	cd $(AUTOV8_DIR); git checkout $(AUTOV8_VERSION) && \
+		rm -f $(BUILD_DIR)/autov8_gitcheckedout; echo $(shell date) > $(BUILD_DIR)/autov8_gitcheckedout
+
+$(BUILD_DIR)/autov8_gclient_synced: $(BUILD_DIR)/autov8_gitcheckedout
+	cd $(AUTOV8_DIR); gclient sync && \
+		rm -f $(BUILD_DIR)/autov8_gclient_synced; echo $(shell date) > $(BUILD_DIR)/autov8_gclient_synced
+
+$(BUILD_DIR)/autov8_cherry_picked: $(BUILD_DIR)/autov8_gclient_synced
+	cd $(AUTOV8_DIR)/build/config; git cherry-pick 4287a0d364541583a50cc91465330251460d489a && \
+		rm -f $(BUILD_DIR)/autov8_cherry_picked; echo $(shell date) > $(BUILD_DIR)/autov8_cherry_picked
+
+$(BUILD_DIR)/autov8_v8gen: $(BUILD_DIR)/autov8_cherry_picked
+	rm -fr $(AUTOV8_DIR)/out.gn
+	cd $(AUTOV8_DIR); tools/dev/v8gen.py $(PLATFORM) -- $(V8_OPTIONS) && \
+		rm -f $(BUILD_DIR)/autov8_v8gen; echo $(shell date) > $(BUILD_DIR)/autov8_v8gen
 
 $(AUTOV8_OUT)/third_party/icu/common/icudtb.dat:
 
 $(AUTOV8_OUT)/third_party/icu/common/icudtl.dat:
 
-v8: $(AUTOV8_DIR)
+v8: $(BUILD_DIR)/autov8_v8gen
 	cd $(AUTOV8_DIR) ; env CXXFLAGS=-fPIC CFLAGS=-fPIC ninja -C out.gn/$(PLATFORM) d8
 
 include Makefile.shared
@@ -54,10 +79,16 @@ endif
 CCFLAGS += -I$(AUTOV8_DIR)/include -I$(AUTOV8_DIR)
 # We're gonna build static link.  Rip it out after include Makefile
 SHLIB_LINK := $(filter-out -lv8, $(SHLIB_LINK))
-
+PKGCONFIG := na
+PYTHON := na
+GIT := na
+PYTHON_VERSION := na
 ifeq ($(OS),Windows_NT)
 	# noop for now
 else
+	PKGCONFIG := $(shell which pkg-config)
+	PYTHON := $(shell which python)
+	GIT := $(shell which git)
 	SHLIB_LINK += -L$(AUTOV8_OUT)
 	UNAME_S := $(shell uname -s)
 	ifeq ($(UNAME_S),Darwin)
@@ -76,3 +107,21 @@ else
 		SHLIB_LINK += -lrt -std=c++11 -lc++
 	endif
 endif
+
+.PHONY: check-tools
+check-tools:
+ifeq ($(PKGCONFIG),)
+	$(error "(linux) plv8 compilation requires pkg-config(1) - please install.")
+endif
+ifeq ($(PYTHON),)
+	$(error "(linux) plv8 compilation requires python - please install.")
+endif
+ifeq ($(GIT),)
+	$(error "(linux) plv8 compilation requires git - please install.")
+endif
+ifneq ($(PYTHON),)
+ifneq ($(shell $(PYTHON) -c 'import platform;print(platform.python_version_tuple()[0])'),2)
+	$(error "(linux) plv8 compilation requires python2 (e.g. not python 3) - please install.")
+endif
+endif
+

--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ function that is callable from SQL.
     =# CREATE EXTENSION plv8;
 
 This will install PLV8 into your database if it exists as an extension.
+If it does not exist (e.g. "ERROR:  could not open extension control file...") then you will need to build and install plv8, which requires access to the Postgres installation ([learn more](docs/BUILDING.md)).
 
 ## Testing
 

--- a/docker-release.sh
+++ b/docker-release.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+# all-in-one script for performing binary releases to dockerhub
+#
+# end users: please see README.md for how to use these releases
+# developers: feel free to use your own version of this-- see Dockerfile
+
+PLV8_VERSION=2.3.9
+
+# for official releases, login as plv8user
+docker login
+
+for PG_VERSION in {9.6,10,11}; do
+    echo "building for $PG_VERSION..."
+    docker build --build-arg PLV8_VERSION=$PLV8_VERSION --build-arg PG_VERSION=$PG_VERSION -t plv8user/plv8:$PLV8_VERSION-pg$PG_VERSION . > docker-build-$PG_VERSION.out 2>&1 &
+done
+
+# build in parallel
+wait
+
+# build times are long, so 
+for PG_VERSION in {9.6,10,11}; do
+    docker push plv8user/plv8:$PLV8_VERSION-pg$PG_VERSION
+done


### PR DESCRIPTION
build succeeds on ubuntu 18 / pg11 (I'll spare you the output).  You can now hit ctrl-C at any time and it cleans up & restarts correctly, without requiring you to restart the whole long build from scratch.

Harsh criticism is fine - this is my first PR to your repo, and have no expectations that you'll like my code esp in Makefile/shell :-)

This is only tested on Ubuntu 18.04.


**installation seems to work**

```
$ sudo make install
echo

cd /home/asah/plv8-2.3.9/build/v8 ; env CXXFLAGS=-fPIC CFLAGS=-fPIC ninja -C out.gn/x64.release d8
ninja: Entering directory `out.gn/x64.release'
ninja: no work to do.
mkdir -p upgrade
./generate_upgrade.sh 2.3.9
/bin/mkdir -p '/usr/lib/postgresql/11/lib'
/bin/mkdir -p '/usr/share/postgresql/11/extension'
/bin/mkdir -p '/usr/share/postgresql/11/extension'
/usr/bin/install -c -m 755  plv8-2.3.9.so '/usr/lib/postgresql/11/lib/plv8-2.3.9.so'
/usr/bin/install -c -m 644 .//plv8.control '/usr/share/postgresql/11/extension/'
/usr/bin/install -c -m 644 .//plv8.control .//plv8--2.3.9.sql .//upgrade/plv8--1.5.0--2.3.9.sql .//upgrade/plv8--2.3.3--2.3.9.sql .//upgrade/plv8--2.0.0--2.3.9.sql .//upgrade/plv8--2.0.3--2.3.9.sql .//upgrade/plv8--1.5.3--2.3.9.sql .//upgrade/plv8--2.3.4--2.3.9.sql .//upgrade/plv8--2.3.1--2.3.9.sql .//upgrade/plv8--1.5.4--2.3.9.sql .//upgrade/plv8--1.5.1--2.3.9.sql .//upgrade/plv8--2.3.7--2.3.9.sql .//upgrade/plv8--2.3.0--2.3.9.sql .//upgrade/plv8--2.3.5--2.3.9.sql .//upgrade/plv8--2.3.2--2.3.9.sql .//upgrade/plv8--1.5.5--2.3.9.sql .//upgrade/plv8--1.5.2--2.3.9.sql .//upgrade/plv8--2.3.6--2.3.9.sql .//upgrade/plv8--2.1.0--2.3.9.sql .//upgrade/plv8--2.0.1--2.3.9.sql .//upgrade/plv8--2.3.8--2.3.9.sql .//upgrade/plv8--1.5.7--2.3.9.sql .//upgrade/plv8--1.5.6--2.3.9.sql .//plcoffee.control .//plcoffee--2.3.9.sql .//plls.control .//plls--2.3.9.sql  '/usr/share/postgresql/11/extension/'
/bin/mkdir -p '/usr/lib/postgresql/11/lib/bitcode/plv8-2.3.9'
/bin/mkdir -p '/usr/lib/postgresql/11/lib/bitcode'/plv8-2.3.9/
/usr/bin/install -c -m 644 plv8.bc '/usr/lib/postgresql/11/lib/bitcode'/plv8-2.3.9/./
/usr/bin/install -c -m 644 plv8_type.bc '/usr/lib/postgresql/11/lib/bitcode'/plv8-2.3.9/./
/usr/bin/install -c -m 644 plv8_func.bc '/usr/lib/postgresql/11/lib/bitcode'/plv8-2.3.9/./
/usr/bin/install -c -m 644 plv8_param.bc '/usr/lib/postgresql/11/lib/bitcode'/plv8-2.3.9/./
/usr/bin/install -c -m 644 coffee-script.bc '/usr/lib/postgresql/11/lib/bitcode'/plv8-2.3.9/./
/usr/bin/install -c -m 644 livescript.bc '/usr/lib/postgresql/11/lib/bitcode'/plv8-2.3.9/./
cd '/usr/lib/postgresql/11/lib/bitcode' && /usr/lib/llvm-6.0/bin/llvm-lto -thinlto -thinlto-action=thinlink -o plv8-2.3.9.index.bc plv8-2.3.9/plv8.bc plv8-2.3.9/plv8_type.bc plv8-2.3.9/plv8_func.bc plv8-2.3.9/plv8_param.bc plv8-2.3.9/coffee-script.bc plv8-2.3.9/livescript.bc
asah@dev-asah-east4-4cpu-2:~/plv8-2.3.9$ sudo su - postgres -c psql
psql (11.2 (Ubuntu 11.2-1.pgdg18.04+1))
Type "help" for help.

postgres=# create extension plv8;
CREATE EXTENSION
postgres=# SELECT plv8_version();
 plv8_version
--------------
 2.3.9
(1 row)
```

**self-tests seem to pass**

```
$ sudo su postgres -c "make installcheck"
/usr/lib/postgresql/11/lib/pgxs/src/makefiles/../../src/test/regress/pg_regress --inputdir=./ --bindir='/usr/lib/postgresql/11/bin'    --dbname=contrib_regression init-extension plv8 plv8-errors inline json startup_pre startup varparam json_conv jsonb_conv window guc es6 arraybuffer composites currentresource startup_perms bytea dialect
(using postmaster on Unix socket, default port)
============== dropping database "contrib_regression" ==============
DROP DATABASE
============== creating database "contrib_regression" ==============
CREATE DATABASE
ALTER DATABASE
============== running regression test queries        ==============
test init-extension               ... ok
test plv8                         ... ok
test plv8-errors                  ... ok
test inline                       ... ok
test json                         ... ok
test startup_pre                  ... ok
test startup                      ... ok
test varparam                     ... ok
test json_conv                    ... ok
test jsonb_conv                   ... ok
test window                       ... ok
test guc                          ... ok
test es6                          ... ok
test arraybuffer                  ... ok
test composites                   ... ok
test currentresource              ... ok
test startup_perms                ... ok
test bytea                        ... ok
test dialect                      ... ok

======================
 All 19 tests passed.
======================
```