### PR TITLE
Oom handling

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ before_install:
   - sudo apt-get -y --purge remove postgresql libpq-dev libpq5 postgresql-client-common postgresql-common
   - sudo rm -rf /var/lib/postgresql
   - wget --no-check-certificate  --quiet -O - https://www.postgresql.org/media/keys/ACCC4CF8.asc | sudo apt-key add -
-  - sudo sh -c "echo deb http://apt.postgresql.org/pub/repos/apt/ trusty-pgdg main $PGVERSION >> /etc/apt/sources.list.d/postgresql.list"
+  - sudo sh -c "echo deb http://apt.postgresql.org/pub/repos/apt/ xenial-pgdg main $PGVERSION >> /etc/apt/sources.list.d/postgresql.list"
   - sudo apt-get update -qq
   - sudo apt-get -y -o Dpkg::Options::=--force-confdef -o Dpkg::Options::="--force-confnew" install postgresql-$PGVERSION postgresql-server-dev-$PGVERSION
   - sudo chmod 777 /etc/postgresql/$PGVERSION/main/pg_hba.conf
@@ -13,18 +13,11 @@ before_install:
   - sudo echo "host    all         all         127.0.0.1/32          trust" >> /etc/postgresql/$PGVERSION/main/pg_hba.conf
   - sudo echo "host    all         all         ::1/128               trust" >> /etc/postgresql/$PGVERSION/main/pg_hba.conf
   - sudo /etc/init.d/postgresql restart
-  - sudo add-apt-repository ppa:ubuntu-toolchain-r/test -y
-  - sudo apt-get update -qq
-  - sudo apt-get install -y libc6-dev-i386 libc++-dev libstdc++-4.9-dev
-  - if [ "$CXX" = "g++" ]; then sudo apt-get install -qq g++-4.9; fi
-  - if [ "$CXX" = "g++" ]; then export CXX="g++-4.9" CC="gcc-4.9" LD="g++-4.9"; fi
-  - sudo update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-4.9 90
 
 before_script:
   - g++ -v
   - gcc -v
   - createuser -U postgres -s travis
-
 
 env:
   matrix:
@@ -34,14 +27,12 @@ env:
     - PGVERSION=9.4
     - PGVERSION=9.2
 
-
-
 language: cpp
 compiler:
   - gcc
 
 sudo: required
-dist: trusty
+dist: xenial
 
 script:
   - make && sudo make install && make installcheck

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,7 @@ before_install:
   - sudo /etc/init.d/postgresql restart
   - sudo add-apt-repository ppa:ubuntu-toolchain-r/test -y
   - sudo apt-get update -qq
-  - sudo apt-get install -y libc6-dev-i386 libc++-dev
+  - sudo apt-get install -y libc6-dev-i386 libc++-dev libstdc++-4.9-dev
   - if [ "$CXX" = "g++" ]; then sudo apt-get install -qq g++-4.9; fi
   - if [ "$CXX" = "g++" ]; then export CXX="g++-4.9" CC="gcc-4.9" LD="g++-4.9"; fi
   - sudo update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-4.9 90

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,9 +16,9 @@ before_install:
   - sudo add-apt-repository ppa:ubuntu-toolchain-r/test -y
   - sudo apt-get update -qq
   - sudo apt-get install -y libc6-dev-i386 libc++-dev
-  - if [ "$CXX" = "g++" ]; then sudo apt-get install -qq g++-4.8; fi
-  - if [ "$CXX" = "g++" ]; then export CXX="g++-4.8" CC="gcc-4.8" LD="g++-4.8"; fi
-  - sudo update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-4.8 90
+  - if [ "$CXX" = "g++" ]; then sudo apt-get install -qq g++-4.9; fi
+  - if [ "$CXX" = "g++" ]; then export CXX="g++-4.9" CC="gcc-4.9" LD="g++-4.9"; fi
+  - sudo update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-4.9 90
 
 before_script:
   - g++ -v

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,6 +13,9 @@ before_install:
   - sudo echo "host    all         all         127.0.0.1/32          trust" >> /etc/postgresql/$PGVERSION/main/pg_hba.conf
   - sudo echo "host    all         all         ::1/128               trust" >> /etc/postgresql/$PGVERSION/main/pg_hba.conf
   - sudo /etc/init.d/postgresql restart
+  - sudo add-apt-repository ppa:ubuntu-toolchain-r/test -y
+  - sudo apt-get update -qq
+  - sudo apt-get install -y libc6-dev-i386 libc++-dev
 
 before_script:
   - g++ -v

--- a/Makefile
+++ b/Makefile
@@ -16,7 +16,7 @@ AUTOV8_STATIC_LIBS = -lv8_base -lv8_snapshot -lv8_libplatform -lv8_libbase -lv8_
 export PATH := $(abspath $(AUTOV8_DEPOT_TOOLS)):$(PATH)
 
 SHLIB_LINK += -L$(AUTOV8_OUT) -L$(AUTOV8_OUT)/third_party/icu $(AUTOV8_STATIC_LIBS)
-V8_OPTIONS = is_component_build=false v8_static_library=true v8_use_snapshot=true v8_use_external_startup_data=false is_clang=false use_custom_libcxx=false
+V8_OPTIONS = is_component_build=false v8_static_library=true v8_use_snapshot=true v8_use_external_startup_data=false use_custom_libcxx=false
 
 ifndef USE_ICU
 	V8_OPTIONS += v8_enable_i18n_support=false

--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@
 # structure in v8 which may be different from version to another, but user
 # can specify the v8 version by AUTOV8_VERSION, too.
 #-----------------------------------------------------------------------------#
-AUTOV8_VERSION = 7.0.302
+AUTOV8_VERSION = 7.4.288.28
 AUTOV8_DIR = build/v8
 AUTOV8_OUT = build/v8/out.gn/x64.release/obj
 AUTOV8_DEPOT_TOOLS = build/depot_tools
@@ -16,7 +16,7 @@ AUTOV8_STATIC_LIBS = -lv8_base -lv8_snapshot -lv8_libplatform -lv8_libbase -lv8_
 export PATH := $(abspath $(AUTOV8_DEPOT_TOOLS)):$(PATH)
 
 SHLIB_LINK += -L$(AUTOV8_OUT) -L$(AUTOV8_OUT)/third_party/icu $(AUTOV8_STATIC_LIBS)
-V8_OPTIONS = is_component_build=false v8_static_library=true v8_use_snapshot=true v8_use_external_startup_data=false
+V8_OPTIONS = is_component_build=false v8_static_library=true v8_use_snapshot=true v8_use_external_startup_data=false is_clang=false use_custom_libcxx=false
 
 ifndef USE_ICU
 	V8_OPTIONS += v8_enable_i18n_support=false
@@ -52,7 +52,7 @@ ifdef BIGINT_GRACEFUL
 endif
 
 # enable direct jsonb conversion by default
-CCFLAGS += -DJSONB_DIRECT_CONVERSION 
+CCFLAGS += -DJSONB_DIRECT_CONVERSION
 
 CCFLAGS += -I$(AUTOV8_DIR)/include -I$(AUTOV8_DIR)
 # We're gonna build static link.  Rip it out after include Makefile

--- a/Makefile.shared
+++ b/Makefile.shared
@@ -25,7 +25,7 @@ CUSTOM_CC = g++
 JSS  = coffee-script.js livescript.js
 # .cc created from .js
 JSCS = $(JSS:.js=.cc)
-SRCS = plv8.cc plv8_type.cc plv8_func.cc plv8_param.cc $(JSCS)
+SRCS = plv8.cc plv8_type.cc plv8_func.cc plv8_param.cc plv8_allocator.cc $(JSCS)
 OBJS = $(SRCS:.cc=.o)
 MODULE_big = plv8-$(PLV8_VERSION)
 EXTENSION = plv8
@@ -38,7 +38,8 @@ DATA += plcoffee.control plcoffee--$(PLV8_VERSION).sql \
 endif
 DATA_built = plv8.sql
 REGRESS = init-extension plv8 plv8-errors inline json startup_pre startup varparam json_conv \
- 		  jsonb_conv window guc es6 arraybuffer composites currentresource startup_perms bytea find_function_perms
+		  jsonb_conv window guc es6 arraybuffer composites currentresource startup_perms bytea find_function_perms \
+		  memory_limits array_spread
 ifndef DISABLE_DIALECT
 REGRESS += dialect
 endif

--- a/expected/array_spread.out
+++ b/expected/array_spread.out
@@ -6,8 +6,15 @@ do $$
   };
   [...({})];
 $$ language plv8;
-FATAL:  plv8: OOM error in GC
-server closed the connection unexpectedly
-	This probably means the server terminated abnormally
-	before or while processing the request.
-connection to server was lost
+ERROR:  missing error text
+CONTEXT:  
+do $$
+  Object.prototype[Symbol.iterator] = function() {
+     return {
+       next:() => this
+     }
+  };
+  [...({})];
+$$ language plv8;
+ERROR:  missing error text
+CONTEXT:  

--- a/expected/array_spread.out
+++ b/expected/array_spread.out
@@ -1,0 +1,13 @@
+do $$
+  Object.prototype[Symbol.iterator] = function() {
+     return {
+       next:() => this
+     }
+  };
+  [...({})];
+$$ language plv8;
+FATAL:  plv8: OOM error in GC
+server closed the connection unexpectedly
+	This probably means the server terminated abnormally
+	before or while processing the request.
+connection to server was lost

--- a/expected/memory_limits.out
+++ b/expected/memory_limits.out
@@ -14,14 +14,11 @@ ERROR:  RangeError: Array buffer allocation failed
 CONTEXT:  undefined() LINE 3:   const a = new ArrayBuffer(limit*1024*1024);
 do $$
   const limit = plv8.execute(`select setting from pg_settings where name = $1`, ['plv8.memory_limit'])[0].setting;
-  const a = new ArrayBuffer(limit*1024*1024/1.01);
+  const a = new ArrayBuffer(limit*1024*1024/1.5);
   const s = [];
   while(true) {
     s.push(new ArrayBuffer(63)) // small non-aligned allocations
   }
 $$ language plv8;
-FATAL:  plv8: OOM in ArrayAllocator
-server closed the connection unexpectedly
-	This probably means the server terminated abnormally
-	before or while processing the request.
-connection to server was lost
+ERROR:  RangeError: Array buffer allocation failed
+CONTEXT:  undefined() LINE 6:     s.push(new ArrayBuffer(63)) // small non-aligned allocations

--- a/expected/memory_limits.out
+++ b/expected/memory_limits.out
@@ -1,0 +1,27 @@
+do $$
+  const limit = plv8.execute(`select setting from pg_settings where name = $1`, ['plv8.memory_limit'])[0].setting;
+  const a = new ArrayBuffer(limit*1024*1024/2);
+$$ language plv8;
+do $$
+  const limit = plv8.execute(`select setting from pg_settings where name = $1`, ['plv8.memory_limit'])[0].setting;
+  const a = new ArrayBuffer(limit*1024*1024/2);
+$$ language plv8;
+do $$
+  const limit = plv8.execute(`select setting from pg_settings where name = $1`, ['plv8.memory_limit'])[0].setting;
+  const a = new ArrayBuffer(limit*1024*1024);
+$$ language plv8;
+ERROR:  RangeError: Array buffer allocation failed
+CONTEXT:  undefined() LINE 3:   const a = new ArrayBuffer(limit*1024*1024);
+do $$
+  const limit = plv8.execute(`select setting from pg_settings where name = $1`, ['plv8.memory_limit'])[0].setting;
+  const a = new ArrayBuffer(limit*1024*1024/1.01);
+  const s = [];
+  while(true) {
+    s.push(new ArrayBuffer(63)) // small non-aligned allocations
+  }
+$$ language plv8;
+FATAL:  plv8: OOM in ArrayAllocator
+server closed the connection unexpectedly
+	This probably means the server terminated abnormally
+	before or while processing the request.
+connection to server was lost

--- a/plv8_allocator.cc
+++ b/plv8_allocator.cc
@@ -20,12 +20,7 @@ bool ArrayAllocator::check(const size_t length) {
 			plv8_isolate->LowMemoryNotification();
 			heap_size = heap_statistics.total_heap_size();
 			if (heap_size + allocated + length > heap_limit) {
-				if (length <= 64) {
-					// we need to bail out here, otherwise v8 itself will abort
-					elog(FATAL, "plv8: OOM in ArrayAllocator");
-				} else {
-					return false;
-				}
+				return false;
 			}
 		}
 		next_size = heap_size + allocated + length + RECHECK_INCREMENT;

--- a/plv8_allocator.cc
+++ b/plv8_allocator.cc
@@ -1,0 +1,57 @@
+#include "plv8_allocator.h"
+
+#define RECHECK_INCREMENT 1_MB
+
+size_t operator""_MB( unsigned long long const x ) { return 1024L * 1024L * x; }
+
+ArrayAllocator::ArrayAllocator(size_t limit) : heap_limit(limit),
+											   heap_size(RECHECK_INCREMENT),
+											   next_size(RECHECK_INCREMENT),
+											   allocated(0) {}
+
+bool ArrayAllocator::check(const size_t length) {
+	if (heap_size + allocated + length > next_size) {
+		v8::HeapStatistics heap_statistics;
+		plv8_isolate->GetHeapStatistics(&heap_statistics);
+		heap_size = heap_statistics.total_heap_size();
+		if (heap_size + allocated + length > heap_limit) {
+			// wee need to force GC here,
+			// otherwise the next allocation will fail even if there is a space for it
+			plv8_isolate->LowMemoryNotification();
+			heap_size = heap_statistics.total_heap_size();
+			if (heap_size + allocated + length > heap_limit) {
+				if (length <= 64) {
+					// we need to bail out here, otherwise v8 itself will abort
+					elog(FATAL, "plv8: OOM in ArrayAllocator");
+				} else {
+					return false;
+				}
+			}
+		}
+		next_size = heap_size + allocated + length + RECHECK_INCREMENT;
+	}
+	allocated += length;
+	return true;
+}
+
+void* ArrayAllocator::Allocate(size_t length) {
+	if (check(length)) {
+		return std::calloc(length, 1);
+	} else {
+		return nullptr;
+	}
+}
+
+void* ArrayAllocator::AllocateUninitialized(size_t length) {
+	if (check(length)) {
+		return std::malloc(length);
+	} else {
+		return nullptr;
+	}
+}
+
+void ArrayAllocator::Free(void* data, size_t length) {
+	allocated -= length;
+	next_size -= length;
+	std::free(data);
+}

--- a/plv8_allocator.h
+++ b/plv8_allocator.h
@@ -1,0 +1,25 @@
+#ifndef PLV8_PLV8_ALLOCATOR_H
+#define PLV8_PLV8_ALLOCATOR_H
+
+#include <v8.h>
+#include "plv8.h"
+
+size_t operator""_MB( unsigned long long x );
+
+class ArrayAllocator : public v8::ArrayBuffer::Allocator {
+private:
+	size_t heap_limit;
+	size_t heap_size;
+	size_t next_size;
+	size_t allocated;
+
+	bool check(size_t length);
+
+public:
+	explicit ArrayAllocator(size_t limit);
+	void* Allocate(size_t length) final;
+	void* AllocateUninitialized(size_t length) final;
+	void Free(void* data, size_t length) final;
+};
+
+#endif //PLV8_PLV8_ALLOCATOR_H

--- a/plv8_type.cc
+++ b/plv8_type.cc
@@ -452,7 +452,7 @@ static JsonbValue *
 JsonbArrayFromArray(JsonbParseState **pstate, Local<v8::Object> object) {
 	JsonbValue *val = pushJsonbValue(pstate, WJB_BEGIN_ARRAY, NULL);
 	Local<v8::Array> a = Local<v8::Array>::Cast(object);
-	for (int32 i = 0; i < a->Length(); i++) {
+	for (size_t i = 0; i < a->Length(); i++) {
 		Local<v8::Value> o = a->Get(i);
 
 		if (o->IsArray()) {
@@ -474,7 +474,7 @@ JsonbObjectFromObject(JsonbParseState **pstate, Local<v8::Object> object) {
 	JsonbValue *val = pushJsonbValue(pstate, WJB_BEGIN_OBJECT, NULL);
 	Local<Array> arr = object->GetOwnPropertyNames(plv8_isolate->GetCurrentContext()).ToLocalChecked();
 
-	for (int32 i = 0; i < arr->Length(); i++) {
+	for (size_t i = 0; i < arr->Length(); i++) {
 		Local<v8::Value> v = arr->Get(i);
 		val = JsonbFromValue(pstate, v, WJB_KEY);
 		Local<v8::Value> o = object->Get(v);
@@ -672,7 +672,7 @@ ToScalarDatum(Handle<v8::Value> value, bool *isnull, plv8_type *type)
 	case NUMERICOID:
 		if (value->IsBigInt()) {
 			String::Utf8Value utf8(plv8_isolate, value->ToString(plv8_isolate));
-			return DirectFunctionCall3(numeric_in, (Datum) *utf8, NULL, Int32GetDatum((int32) -1));
+			return DirectFunctionCall3(numeric_in, (Datum) *utf8, ObjectIdGetDatum(InvalidOid), Int32GetDatum((int32) -1));
 		}
 		if (value->IsNumber())
 			return DirectFunctionCall1(float8_numeric,

--- a/plv8_type.cc
+++ b/plv8_type.cc
@@ -472,7 +472,7 @@ JsonbArrayFromArray(JsonbParseState **pstate, Local<v8::Object> object) {
 static JsonbValue *
 JsonbObjectFromObject(JsonbParseState **pstate, Local<v8::Object> object) {
 	JsonbValue *val = pushJsonbValue(pstate, WJB_BEGIN_OBJECT, NULL);
-	Local<Array> arr = object->GetOwnPropertyNames();
+	Local<Array> arr = object->GetOwnPropertyNames(plv8_isolate->GetCurrentContext()).ToLocalChecked();
 
 	for (int32 i = 0; i < arr->Length(); i++) {
 		Local<v8::Value> v = arr->Get(i);
@@ -938,10 +938,10 @@ ToScalarValue(Datum datum, bool isnull, plv8_type *type)
 		return Number::New(plv8_isolate, DatumGetFloat8(
 			DirectFunctionCall1(numeric_float8, datum)));
 	case DATEOID:
-		return Date::New(plv8_isolate, DateToEpoch(DatumGetDateADT(datum)));
+		return Date::New(plv8_isolate->GetCurrentContext(), DateToEpoch(DatumGetDateADT(datum))).ToLocalChecked();
 	case TIMESTAMPOID:
 	case TIMESTAMPTZOID:
-		return Date::New(plv8_isolate, TimestampTzToEpoch(DatumGetTimestampTz(datum)));
+		return Date::New(plv8_isolate->GetCurrentContext(), TimestampTzToEpoch(DatumGetTimestampTz(datum))).ToLocalChecked();
 	case TEXTOID:
 	case VARCHAROID:
 	case BPCHAROID:

--- a/sql/array_spread.sql
+++ b/sql/array_spread.sql
@@ -6,3 +6,11 @@ do $$
   };
   [...({})];
 $$ language plv8;
+do $$
+  Object.prototype[Symbol.iterator] = function() {
+     return {
+       next:() => this
+     }
+  };
+  [...({})];
+$$ language plv8;

--- a/sql/array_spread.sql
+++ b/sql/array_spread.sql
@@ -1,0 +1,8 @@
+do $$
+  Object.prototype[Symbol.iterator] = function() {
+     return {
+       next:() => this
+     }
+  };
+  [...({})];
+$$ language plv8;

--- a/sql/memory_limits.sql
+++ b/sql/memory_limits.sql
@@ -1,0 +1,23 @@
+do $$
+  const limit = plv8.execute(`select setting from pg_settings where name = $1`, ['plv8.memory_limit'])[0].setting;
+  const a = new ArrayBuffer(limit*1024*1024/2);
+$$ language plv8;
+
+do $$
+  const limit = plv8.execute(`select setting from pg_settings where name = $1`, ['plv8.memory_limit'])[0].setting;
+  const a = new ArrayBuffer(limit*1024*1024/2);
+$$ language plv8;
+
+do $$
+  const limit = plv8.execute(`select setting from pg_settings where name = $1`, ['plv8.memory_limit'])[0].setting;
+  const a = new ArrayBuffer(limit*1024*1024);
+$$ language plv8;
+
+do $$
+  const limit = plv8.execute(`select setting from pg_settings where name = $1`, ['plv8.memory_limit'])[0].setting;
+  const a = new ArrayBuffer(limit*1024*1024/1.01);
+  const s = [];
+  while(true) {
+    s.push(new ArrayBuffer(63)) // small non-aligned allocations
+  }
+$$ language plv8;

--- a/sql/memory_limits.sql
+++ b/sql/memory_limits.sql
@@ -15,7 +15,7 @@ $$ language plv8;
 
 do $$
   const limit = plv8.execute(`select setting from pg_settings where name = $1`, ['plv8.memory_limit'])[0].setting;
-  const a = new ArrayBuffer(limit*1024*1024/1.01);
+  const a = new ArrayBuffer(limit*1024*1024/1.5);
   const s = [];
   while(true) {
     s.push(new ArrayBuffer(63)) // small non-aligned allocations


### PR DESCRIPTION
there were the following corner cases found:
- allocate two big arrays (but smaller than heap limit) in subsequent isolate runs: should not fail
- allocate array over the heap limit in small increments (less than 64 bytes): should throw error
- run array spread bug repro: should fail with error
- run array spread repro twice: should fail with error twice

right now all these cases are handled correctly