### PR TITLE
fix doc: keep the $$ (it was replaced to $ currently)

### DIFF
--- a/contrib/web/index.js
+++ b/contrib/web/index.js
@@ -47,7 +47,7 @@ files.forEach((elem) => {
 });
 
 // replace the content of the template
-template = template.replace('%CONTENT%', content);
+template = template.replace('%CONTENT%', () => content);
 
 // create the links for the sidebar
 var level = 0;
@@ -67,7 +67,7 @@ links.forEach((elem) => {
 });
 
 // replace the content of the sidebar
-template = template.replace('%SIDEBAR%', sidebar);
+template = template.replace('%SIDEBAR%', () => sidebar);
 
 // write the output
 fs.writeFileSync('index.html', template, 'utf8');


### PR DESCRIPTION
I found that all `$$` became `$` currently due to the string.replace of js treats `$$` specially (insert a single $) in some case.

MDN has detail explanation at [here](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/replace#Specifying_a_string_as_a_parameter).


To disable this special behavior, just using a function to replace the new string.