### PR TITLE
Allocate FunctionCallInfo on the stack.

### DIFF
--- a/plv8.cc
+++ b/plv8.cc
@@ -1598,7 +1598,9 @@ GetGlobalContext(Persistent<Context>& global_context)
 #if PG_VERSION_NUM < 120000
 			FunctionCallInfoData fake_fcinfo;
 #else
-			FunctionCallInfo fake_fcinfo;
+			// Stack-allocate FunctionCallInfoBaseData with
+			// space for 2 arguments:
+			LOCAL_FCINFO(fake_fcinfo, 2);
 #endif
 			FmgrInfo	flinfo;
 
@@ -1620,7 +1622,6 @@ GetGlobalContext(Persistent<Context>& global_context)
 				fake_fcinfo.arg[1] = CStringGetDatum(arg);
 				Datum ret = has_function_privilege_id(&fake_fcinfo);
 #else
-				MemSet(fake_fcinfo, 0, sizeof(fake_fcinfo));
 				MemSet(&flinfo, 0, sizeof(flinfo));
 				fake_fcinfo->flinfo = &flinfo;
 				flinfo.fn_oid = InvalidOid;

--- a/plv8_func.cc
+++ b/plv8_func.cc
@@ -1072,7 +1072,9 @@ plv8_FindFunction(const FunctionCallbackInfo<v8::Value>& args)
 #if PG_VERSION_NUM < 120000
 	FunctionCallInfoData fake_fcinfo;
 #else
-	FunctionCallInfo fake_fcinfo;
+	// Stack-allocate FunctionCallInfoBaseData with
+	// space for 2 arguments:
+	LOCAL_FCINFO(fake_fcinfo, 2);
 #endif
 	FmgrInfo	flinfo;
 	text *arg;
@@ -1102,7 +1104,6 @@ plv8_FindFunction(const FunctionCallbackInfo<v8::Value>& args)
 				fake_fcinfo.arg[1] = CStringGetDatum(arg);
 				Datum ret = has_function_privilege_id(&fake_fcinfo);
 #else
-				MemSet(fake_fcinfo, 0, sizeof(fake_fcinfo));
 				MemSet(&flinfo, 0, sizeof(flinfo));
 				fake_fcinfo->flinfo = &flinfo;
 				flinfo.fn_oid = InvalidOid;


### PR DESCRIPTION
FunctionCallInfoData is defined differently
for PG_VERSION_NUM >= 120000; use a macro
from fmgr.h to initialize it.