### PR TITLE
set an error message for OOM case(s)

### DIFF
--- a/expected/array_spread.out
+++ b/expected/array_spread.out
@@ -6,8 +6,7 @@ do $$
   };
   [...({})];
 $$ language plv8;
-ERROR:  missing error text
-CONTEXT:  
+ERROR:  Out of memory error
 do $$
   Object.prototype[Symbol.iterator] = function() {
      return {
@@ -16,5 +15,4 @@ do $$
   };
   [...({})];
 $$ language plv8;
-ERROR:  missing error text
-CONTEXT:  
+ERROR:  Out of memory error

--- a/plv8.cc
+++ b/plv8.cc
@@ -614,8 +614,11 @@ DoCall(Local<Context> ctx, Handle<Function> fn, Handle<Object> receiver,
 	signal(SIGINT, (void (*)(int)) int_handler);
 	signal(SIGTERM, (void (*)(int)) term_handler);
 
-	if (result.IsEmpty())
+	if (result.IsEmpty()) {
+		if (plv8_isolate->IsExecutionTerminating())
+			throw js_error("Out of memory error");
 		throw js_error(try_catch);
+	}
 
 	if (status < 0)
 		throw js_error(FormatSPIStatus(status));
@@ -1272,8 +1275,11 @@ CompileDialect(const char *src, Dialect dialect)
 		v8::Local<v8::Value> result;
 		if (!script->Run(plv8_isolate->GetCurrentContext()).ToLocal(&result))
 			throw js_error(try_catch);
-		if (result.IsEmpty())
+		if (result.IsEmpty()) {
+			if (plv8_isolate->IsExecutionTerminating())
+				throw js_error("Script is out of memory");
 			throw js_error(try_catch);
+		}
 	}
 
 	Local<Object>	compiler = Local<Object>::Cast(ctx->Global()->Get(key));
@@ -1285,8 +1291,11 @@ CompileDialect(const char *src, Dialect dialect)
 	args[0] = ToString(src);
 	MaybeLocal<v8::Value>	value = func->Call(ctx, compiler, nargs, args);
 
-	if (value.IsEmpty())
+	if (value.IsEmpty()) {
+		if (plv8_isolate->IsExecutionTerminating())
+			throw js_error("Out of memory error");
 		throw js_error(try_catch);
+	}
 	CString		result(value.ToLocalChecked());
 
 	PG_TRY();
@@ -1427,8 +1436,11 @@ CompileFunction(
 	v8::Local<v8::Value> result;
 	if (!script->Run(plv8_isolate->GetCurrentContext()).ToLocal(&result))
 		throw js_error(try_catch);
-	if (result.IsEmpty())
+	if (result.IsEmpty()) {
+		if (plv8_isolate->IsExecutionTerminating())
+			throw js_error("Script is out of memory");
 		throw js_error(try_catch);
+	}
 
 	return handle_scope.Escape(Local<Function>::Cast(result));
 }


### PR DESCRIPTION
when OOM we call `TerminateExecution()` which does not set any error
message
this commit sets correct "Out of memory" error to be displayed in the
runtime or compilation phases

fixes #393 