### PR TITLE
Changes to build against PG13. This includes the removal of a referen…

### DIFF
--- a/plv8.cc
+++ b/plv8.cc
@@ -38,6 +38,10 @@ extern "C" {
 #include "catalog/pg_database.h"
 #endif
 
+#if PG_VERSION_NUM >= 130000
+#include "common/hashfn.h"
+#endif
+
 #include <signal.h>
 
 #ifdef EXECUTION_TIMEOUT
@@ -991,9 +995,7 @@ common_pl_call_validator(PG_FUNCTION_ARGS, Dialect dialect) throw()
 	/* except for TRIGGER, RECORD, INTERNAL, VOID or polymorphic types */
 	if (functyptype == TYPTYPE_PSEUDO)
 	{
-		/* we assume OPAQUE with no arguments means a trigger */
-		if (proc->prorettype == TRIGGEROID ||
-			(proc->prorettype == OPAQUEOID && proc->pronargs == 0))
+                if (proc->prorettype == TRIGGEROID)
 			is_trigger = true;
 		else if (proc->prorettype != RECORDOID &&
 			proc->prorettype != VOIDOID &&

--- a/plv8.cc
+++ b/plv8.cc
@@ -995,7 +995,13 @@ common_pl_call_validator(PG_FUNCTION_ARGS, Dialect dialect) throw()
 	/* except for TRIGGER, RECORD, INTERNAL, VOID or polymorphic types */
 	if (functyptype == TYPTYPE_PSEUDO)
 	{
+#if PG_VERSION_NUM >= 130000
                 if (proc->prorettype == TRIGGEROID)
+#else
+                /* we assume OPAQUE with no arguments means a trigger */
+                if (proc->prorettype == TRIGGEROID ||
+                        (proc->prorettype == OPAQUEOID && proc->pronargs == 0))
+#endif
 			is_trigger = true;
 		else if (proc->prorettype != RECORDOID &&
 			proc->prorettype != VOIDOID &&


### PR DESCRIPTION
…ce to OPAQUEOID which has been deprecated long before PLV8 was invented.