### PR TITLE
fixed the PostgreSQL error "attempt to redefine parameter"

### DIFF
--- a/plv8.cc
+++ b/plv8.cc
@@ -44,6 +44,7 @@ extern "C" {
 #endif
 
 #include <stdlib.h>
+#include <string.h>
 
 PG_MODULE_MAGIC;
 
@@ -366,19 +367,16 @@ _PG_init(void)
 		bool noshow;
 		GetConfigOptionByNum( i, (const char **) values, &noshow );
 		for ( int j = 0; j < m; j++ ) {
-			plv8_guc_variable *v = &guc_variables[j];
-			if ( strcmp( values[0], v->name ) == 0 ) {
-				v->exists = true;
+			if ( !strcmp( values[0], guc_variables[j].name ) ) {
+			    guc_variables[j].exists = true;
+			    guc_variables[j].read();
 			}
 		}
 	}
 	// go through all plv8's GUC variables and define or read them accordingly
 	for ( int j = 0; j < m; j++ ) {
-		plv8_guc_variable *v = &guc_variables[j];
-		if ( !v->exists ) {
-			v->define();
-		} else {
-			v->read();
+		if ( !guc_variables[j].exists ) {
+		    guc_variables[j].define();
 		}
 	}
 

--- a/plv8.cc
+++ b/plv8.cc
@@ -235,7 +235,7 @@ declare_plv8_start_proc ( void ) {
 
 static void
 read_plv8_start_proc ( void ) {
-	plv8_start_proc = (char *)GetConfigOption( GUC_PLV8_START_PROC, TRUE, FALSE );
+	plv8_start_proc = (char *)GetConfigOption( GUC_PLV8_START_PROC, true, false );
 }
 
 static void
@@ -255,7 +255,7 @@ declare_plv8_icu_data ( void ) {
 
 static void
 read_plv8_icu_data ( void ) {
-	plv8_icu_data = (char *)GetConfigOption( GUC_PLV8_ICU_DATA, TRUE, FALSE );
+	plv8_icu_data = (char *)GetConfigOption( GUC_PLV8_ICU_DATA, true, false );
 }
 
 static void
@@ -275,7 +275,7 @@ declare_plv8_v8_flags ( void ) {
 
 static void
 read_plv8_v8_flags ( void ) {
-	plv8_v8_flags = (char *)GetConfigOption( GUC_PLV8_V8_FLAGS, TRUE, FALSE );
+	plv8_v8_flags = (char *)GetConfigOption( GUC_PLV8_V8_FLAGS, true, false );
 }
 
 static void
@@ -297,7 +297,7 @@ declare_plv8_debugger_port ( void ) {
 static void
 read_plv8_debugger_port ( void ) {
 	const char *hint;
-	const char *value = GetConfigOption( GUC_PLV8_DEBUGGER_PORT, TRUE, FALSE );
+	const char *value = GetConfigOption( GUC_PLV8_DEBUGGER_PORT, true, false );
 	parse_int ( value, &plv8_debugger_port, 0, &hint );
 }
 
@@ -321,7 +321,7 @@ declare_plv8_execution_timeout ( void ) {
 static void
 read_plv8_execution_timeout ( void ) {
 	const char *hint;
-	const char *value = GetConfigOption( GUC_PLV8_EXECUTION_TIMEOUT, TRUE, FALSE );
+	const char *value = GetConfigOption( GUC_PLV8_EXECUTION_TIMEOUT, true, false );
 	parse_int ( value, &plv8_execution_timeout, 0, &hint );
 }
 #endif


### PR DESCRIPTION
This error is caused by trying to redeclare a GUC variable that already exists.
It may happen during an upgrade of PLV8 if the previous library is loaded before the new one.
In our case it happened when upgrading from 2.3.13 to 2.3.15.
Since it seems that PostgreSQL API is not publishing a function to check whether a GUC variable already exists or not, this patch used the approach of scanning through all declared variables and check whether the ones from PLV8 are already in that list or not. If a variable is in the list then it reads the current value, if not then it is created.