### PR TITLE
fix plv8_reset isolate disposal

### DIFF
--- a/plv8.cc
+++ b/plv8.cc
@@ -502,13 +502,6 @@ plv8_reset(PG_FUNCTION_ARGS)
 				}
 				cache = (plv8_proc_cache *) hash_seq_search(&status);
 			}
-			context->context.Reset();
-			context->recv_templ.Reset();
-			context->compile_context.Reset();
-			context->plan_template.Reset();
-			context->cursor_template.Reset();
-			context->window_template.Reset();
-			delete context->array_buffer_allocator;
 			context->isolate->Dispose();
 			pfree(context);
 			break;


### PR DESCRIPTION
some of my assumption on how stuff is disposed off were incorrect
fixed it

`Isolate::Dispose()` uses pretty complex logic that deletes stuff in particular order
And the main problem: it deletes the array allocator, which means managing allocator lifecycle externally is kinda prohibited
Got SEGFAULTs in pretty convoluted cases, which are hard to reproduce with a simple test...