### PR TITLE
adds arm64 support

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,9 +7,31 @@
 # structure in v8 which may be different from version to another, but user
 # can specify the v8 version by AUTOV8_VERSION, too.
 #-----------------------------------------------------------------------------#
+
+# Platform detection
+ifeq ($(OS),Windows_NT)
+	# noop for now
+else
+	UNAME_S := $(shell uname -s)
+	ifeq ($(UNAME_S),Darwin)
+		PLATFORM = x64.release
+	endif
+	ifeq ($(UNAME_S),Linux)
+		ifeq ($(shell uname -m | grep -o arm),arm)
+			PLATFORM = arm64.release
+		endif
+		ifeq ($(shell uname -m),aarch64)
+			PLATFORM = arm64.release
+		endif
+		ifeq ($(shell uname -m),x86_64)
+			PLATFORM = x64.release
+		endif
+	endif
+endif
+
 AUTOV8_VERSION = 7.4.288.28
 AUTOV8_DIR = build/v8
-AUTOV8_OUT = build/v8/out.gn/x64.release/obj
+AUTOV8_OUT = build/v8/out.gn/$(PLATFORM)/obj
 AUTOV8_DEPOT_TOOLS = build/depot_tools
 AUTOV8_LIB = $(AUTOV8_OUT)/libv8_snapshot.a
 AUTOV8_STATIC_LIBS = -lv8_base -lv8_snapshot -lv8_libplatform -lv8_libbase -lv8_libsampler
@@ -31,8 +53,33 @@ $(AUTOV8_DEPOT_TOOLS):
 	mkdir -p build
 	cd build; git clone https://chromium.googlesource.com/chromium/tools/depot_tools.git
 
+ifeq ($(PLATFORM),arm64.release)
+$(AUTOV8_DIR): $(AUTOV8_DEPOT_TOOLS)
+	# patch with system-installed ninja
+	cp /usr/bin/ninja build/depot_tools/
+
+	# get ARM64 clang binaries
+	cd build; wget -nc http://releases.llvm.org/7.0.1/clang+llvm-7.0.1-aarch64-linux-gnu.tar.xz; tar xf clang+llvm-7.0.1-aarch64-linux-gnu.tar.xz
+
+	# Get and build the plugin
+	cd build; wget -nc https://chromium.googlesource.com/chromium/src/+archive/lkgr/tools/clang/plugins.tar.gz; mkdir -p plugin; cd plugin; tar xf ../plugins.tar.gz; clang++ *.cpp -c -I ../clang+llvm-7.0.1-aarch64-linux-gnu/include/ -fPIC -Wall -std=c++14 -fno-rtti -fno-omit-frame-pointer; clang -shared *.o -o libFindBadConstructs.so
+
+	cp build/plugin/libFindBadConstructs.so build/clang+llvm-7.0.1-aarch64-linux-gnu/lib/
+
+	# Build an ARM64 binary of gn
+	cd build; rm -rf gn; git clone https://gn.googlesource.com/gn; cd gn; git checkout 6ae63300be3e9865a72772e4cb6e1f8f667624c4; sed -i -e "s/-Wl,--icf=all//" build/gen.py; python build/gen.py; ninja -C out
+
+	# clone v8
+	cd build; fetch v8; cd v8; git checkout $(AUTOV8_VERSION); gclient sync
+
+	# patch v8 with our clang and gn
+	cd build/v8; rm -r third_party/llvm-build/Release+Asserts/; mv ../clang+llvm-7.0.1-aarch64-linux-gnu third_party/llvm-build/Release+Asserts; cp ../gn/out/gn buildtools/linux64/gn; 
+
+	cd build/v8; sed -i -e "s/target_cpu=\"x64\" v8_target_cpu=\"arm64/target_cpu=\"arm64\" v8_target_cpu=\"arm64/" infra/mb/mb_config.pyl; tools/dev/v8gen.py $(PLATFORM) -- $(V8_OPTIONS)
+else
 $(AUTOV8_DIR): $(AUTOV8_DEPOT_TOOLS)
 	cd build; fetch v8; cd v8; git checkout $(AUTOV8_VERSION); gclient sync ; cd build/config ; cd ../.. ; tools/dev/v8gen.py $(PLATFORM) -- $(V8_OPTIONS)
+endif
 
 $(AUTOV8_OUT)/third_party/icu/common/icudtb.dat:
 
@@ -66,18 +113,8 @@ else
 	ifeq ($(UNAME_S),Darwin)
 		CCFLAGS += -stdlib=libc++ -std=c++11
 		SHLIB_LINK += -stdlib=libc++
-		PLATFORM = x64.release
 	endif
 	ifeq ($(UNAME_S),Linux)
-		ifeq ($(shell uname -m | grep -o arm),arm)
-			PLATFORM = arm64.release
-		endif
-		ifeq ($(shell uname -m),aarch64)
-			PLATFORM = arm64.release
-		endif
-		ifeq ($(shell uname -m),x86_64)
-			PLATFORM = x64.release
-		endif
 		CCFLAGS += -std=c++11
 		SHLIB_LINK += -lrt -std=c++11 -lc++
 	endif

--- a/Makefile
+++ b/Makefile
@@ -62,12 +62,12 @@ $(AUTOV8_DIR): $(AUTOV8_DEPOT_TOOLS)
 	cd build; wget -nc http://releases.llvm.org/7.0.1/clang+llvm-7.0.1-aarch64-linux-gnu.tar.xz; tar xf clang+llvm-7.0.1-aarch64-linux-gnu.tar.xz
 
 	# Get and build the plugin
-	cd build; wget -nc https://chromium.googlesource.com/chromium/src/+archive/lkgr/tools/clang/plugins.tar.gz; mkdir -p plugin; cd plugin; tar xf ../plugins.tar.gz; clang++ *.cpp -c -I ../clang+llvm-7.0.1-aarch64-linux-gnu/include/ -fPIC -Wall -std=c++14 -fno-rtti -fno-omit-frame-pointer; clang -shared *.o -o libFindBadConstructs.so
+	cd build; export PATH=$$PATH:`pwd`/clang+llvm-7.0.1-aarch64-linux-gnu/bin; wget -nc https://chromium.googlesource.com/chromium/src/+archive/lkgr/tools/clang/plugins.tar.gz; mkdir -p plugin; cd plugin; tar xf ../plugins.tar.gz; clang++ *.cpp -c -I ../clang+llvm-7.0.1-aarch64-linux-gnu/include/ -fPIC -Wall -std=c++14 -fno-rtti -fno-omit-frame-pointer; clang -shared *.o -o libFindBadConstructs.so
 
 	cp build/plugin/libFindBadConstructs.so build/clang+llvm-7.0.1-aarch64-linux-gnu/lib/
 
 	# Build an ARM64 binary of gn
-	cd build; rm -rf gn; git clone https://gn.googlesource.com/gn; cd gn; git checkout 6ae63300be3e9865a72772e4cb6e1f8f667624c4; sed -i -e "s/-Wl,--icf=all//" build/gen.py; python build/gen.py; ninja -C out
+	cd build; export PATH=$$PATH:`pwd`/clang+llvm-7.0.1-aarch64-linux-gnu/bin; rm -rf gn; git clone https://gn.googlesource.com/gn; cd gn; git checkout 6ae63300be3e9865a72772e4cb6e1f8f667624c4; sed -i -e "s/-Wl,--icf=all//" build/gen.py; python build/gen.py; ninja -C out
 
 	# clone v8
 	cd build; fetch v8; cd v8; git checkout $(AUTOV8_VERSION); gclient sync


### PR DESCRIPTION
Hi as I mentioned [here](https://github.com/plv8/plv8/issues/413#issuecomment-724826905), I have got support for arm64. Tested it on a AWS Graviton instance running ubuntu18.04. 

The installation process for v8 on ARM is not pretty though. I built upon the code from [here](https://github.com/sqreen/PyMiniRacer/blob/4e4d0731a74e6f7a0a55186fb5078ae90b06e19a/build_linux_arm64.sh) and [here](https://github.com/hypersleep/rails-on-arm/blob/master/Dockerfile).