### PR TITLE
bug: string input in bytea garbled

### DIFF
--- a/expected/bytea.out
+++ b/expected/bytea.out
@@ -31,3 +31,14 @@ SELECT length(valid_int16array_bytea(20));
      40
 (1 row)
 
+DO $$
+  const test = 'string test'
+  const bytea = plv8.execute(`select $1::bytea`, [test])[0].bytea;
+  const result = String.fromCharCode.apply(null, bytea);
+  if (result === test) {
+    plv8.elog(INFO, 'OK');
+  } else {
+    plv8.elog(WARN, 'FAIL');
+  }
+$$ language plv8;
+INFO:  OK

--- a/plv8_type.cc
+++ b/plv8_type.cc
@@ -758,6 +758,7 @@ ToScalarDatum(Handle<v8::Value> value, bool *isnull, plv8_type *type)
 				return PointerGetDatum(datum_p);
 			}
 		}
+		break;
 #if PG_VERSION_NUM >= 90400
 	case JSONBOID:
 #if JSONB_DIRECT_CONVERSION

--- a/sql/bytea.sql
+++ b/sql/bytea.sql
@@ -21,3 +21,14 @@ AS $$
 $$;
 
 SELECT length(valid_int16array_bytea(20));
+
+DO $$
+  const test = 'string test'
+  const bytea = plv8.execute(`select $1::bytea`, [test])[0].bytea;
+  const result = String.fromCharCode.apply(null, bytea);
+  if (result === test) {
+    plv8.elog(INFO, 'OK');
+  } else {
+    plv8.elog(WARN, 'FAIL');
+  }
+$$ language plv8;


### PR DESCRIPTION
fixes a garbage created in byte fields if string is used as input and
not an *Array type