### PR TITLE
Use a specific version of depot_tools

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -51,7 +51,7 @@ plv8_config.h plv8.so: v8
 
 $(AUTOV8_DEPOT_TOOLS):
 	mkdir -p build
-	cd build; git clone https://chromium.googlesource.com/chromium/tools/depot_tools.git
+	cd build; git clone https://chromium.googlesource.com/chromium/tools/depot_tools.git; cd chromium; git checkout 3600164d99d9593faa4285cf79ced33caa999c223
 
 ifeq ($(PLATFORM),arm64.release)
 $(AUTOV8_DIR): $(AUTOV8_DEPOT_TOOLS)

--- a/Makefile
+++ b/Makefile
@@ -51,7 +51,7 @@ plv8_config.h plv8.so: v8
 
 $(AUTOV8_DEPOT_TOOLS):
 	mkdir -p build
-	cd build; git clone https://chromium.googlesource.com/chromium/tools/depot_tools.git
+	cd build; git clone https://chromium.googlesource.com/chromium/tools/depot_tools.git; cd depot_tools; git checkout 3600164d99d9593faa4285cf79ced33caa999c22
 
 ifeq ($(PLATFORM),arm64.release)
 $(AUTOV8_DIR): $(AUTOV8_DEPOT_TOOLS)


### PR DESCRIPTION
The current version of `plv8` clones `depot_tools` but does not specify a version or commit, so `plv8` ends up grabbing the most recent version of `depot_tools`. This provides a way for unexpected changes to enter `plv8` via `depot_tools`. This PR locks the version of `depot_tools` to a specific commit that we know works, keeping the behavior of `plv8` the same.