### PR TITLE
build: Move CCFLAGS to Makefile.shared

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -134,20 +134,6 @@ v8_rebuild: v8_config v8
 
 include Makefile.shared
 
-ifdef EXECUTION_TIMEOUT
-	CCFLAGS += -DEXECUTION_TIMEOUT
-endif
-
-ifdef BIGINT_GRACEFUL
-	CCFLAGS += -DBIGINT_GRACEFUL
-endif
-
-# enable direct jsonb conversion by default
-CCFLAGS += -DJSONB_DIRECT_CONVERSION
-
-# enable pointer compression support (default for v8 > 8.x)
-CCFLAGS += -DV8_COMPRESS_POINTERS -DV8_31BIT_SMIS_ON_64BIT_ARCH
-
 CCFLAGS += -I$(AUTOV8_DIR)/include -I$(AUTOV8_DIR)
 # We're gonna build static link.  Rip it out after include Makefile
 SHLIB_LINK := $(filter-out -lv8, $(SHLIB_LINK))

--- a/Makefile.shared
+++ b/Makefile.shared
@@ -75,6 +75,20 @@ OPTFLAGS = -std=c++14 -fno-rtti -O2 -g
 
 CCFLAGS = -Wall $(OPTFLAGS) $(OPT_ENABLE_DEBUGGER_SUPPORT) -g
 
+ifdef EXECUTION_TIMEOUT
+	CCFLAGS += -DEXECUTION_TIMEOUT
+endif
+
+ifdef BIGINT_GRACEFUL
+	CCFLAGS += -DBIGINT_GRACEFUL
+endif
+
+# enable direct jsonb conversion by default
+CCFLAGS += -DJSONB_DIRECT_CONVERSION
+
+# enable pointer compression support (default for v8 > 8.x)
+CCFLAGS += -DV8_COMPRESS_POINTERS -DV8_31BIT_SMIS_ON_64BIT_ARCH
+
 ifdef V8_SRCDIR
 override CPPFLAGS += -I$(V8_SRCDIR) -I$(V8_SRCDIR)/include
 endif


### PR DESCRIPTION
These defines are required even for distros that build v8 separately so they use `make -f Makefile.shared`.
