### PR TITLE
Chain calls to signal hander to allow cancellation during SQL execution

### DIFF
--- a/plv8.cc
+++ b/plv8.cc
@@ -737,6 +737,25 @@ signal_handler (int sig) {
 	auto running_context = GetPlv8Context();
 	running_context->interrupted = true;
 	running_context->isolate->TerminateExecution();
+
+	// call the old handler if it exists
+	switch(sig) {
+		case SIGINT:
+			if (int_handler != NULL) {
+				((void (*)(int)) int_handler)(sig);
+			}
+			break;
+		case SIGTERM:
+			if (term_handler != NULL) {
+				((void (*)(int)) term_handler)(sig);
+			}
+			break;
+		case SIGABRT:
+			if (abt_handler != NULL) {
+				((void (*)(int)) abt_handler)(sig);
+			}
+			break;
+	}
 }
 
 /*


### PR DESCRIPTION
## Description

This PR adds calls to the previously-existing signal handlers after calling the newly-installed signal handler.

## Reason

The current signal handler calls the `TerminateExecution` method of the currently running v8 isolate.  Calling this method raises an exception, interrupting the currently executing javascript code.  However, if the extension is executing a SQL statement via `plv8.execute` then the isolate is not currently running and the SQL execution, via calls to `SPI_execute` isn't interrupted by the exception.  This means that even after sending a `SIGINT` to the process we will have to wait for it to complete execution, regardless of how long it takes (potentially forever). 

Calling the older signal handlers at the end of the newly installed signal handler ensures we will interrupt both the v8 isolate context as well as the SQL context.