### PR TITLE
Initialize unhandled_promises in plv8_context

### DIFF
--- a/plv8.cc
+++ b/plv8.cc
@@ -1903,7 +1903,7 @@ GetPlv8Context() {
 	}
 	if (!my_context)
 	{
-		my_context = (plv8_context *) MemoryContextAlloc(TopMemoryContext,
+		my_context = (plv8_context *) MemoryContextAllocZero(TopMemoryContext,
 														 sizeof(plv8_context));
 		my_context->is_dead = false;
 		my_context->interrupted = false;


### PR DESCRIPTION
Otherwise, the `unhandled_promises` vector can be initialized with garbage. A better solution would be something like placement new, but since we are using Postgres memory allocator, it is tricky. With zeroing out during the initialization, we depend on the exact implementation of the vector. As far as I know, zeroing out will set `len` = `cap` = 0 and will work correctly afterward.