### PR TITLE
Fix function argument name to avoid clash with SQL/JSON reserved word

### DIFF
--- a/expected/json.out
+++ b/expected/json.out
@@ -1,9 +1,9 @@
 CREATE SCHEMA plv8;
-CREATE FUNCTION valid_json(json text) RETURNS boolean
+CREATE FUNCTION valid_json(js text) RETURNS boolean
 LANGUAGE plv8 IMMUTABLE STRICT
 AS $$
   try {
-    JSON.parse(json);
+    JSON.parse(js);
     return true;
   } catch(e) {
     return false;

--- a/sql/json.sql
+++ b/sql/json.sql
@@ -1,9 +1,9 @@
 CREATE SCHEMA plv8;
-CREATE FUNCTION valid_json(json text) RETURNS boolean
+CREATE FUNCTION valid_json(js text) RETURNS boolean
 LANGUAGE plv8 IMMUTABLE STRICT
 AS $$
   try {
-    JSON.parse(json);
+    JSON.parse(js);
     return true;
   } catch(e) {
     return false;


### PR DESCRIPTION
In case of SQL/JSON implementation (like in Postgres Pro) the word 'json' will be reserved word. So, it shouldn't be used as an argument name in function to avoid test failure.