### PR TITLE
Use the v8 default allocator; necessary in sandbox

### DIFF
--- a/plv8_allocator.cc
+++ b/plv8_allocator.cc
@@ -5,9 +5,14 @@
 size_t operator""_MB( unsigned long long const x ) { return 1024L * 1024L * x; }
 
 ArrayAllocator::ArrayAllocator(size_t limit) : heap_limit(limit),
+											   allocator(v8::ArrayBuffer::Allocator::NewDefaultAllocator()),
 											   heap_size(RECHECK_INCREMENT),
 											   next_size(RECHECK_INCREMENT),
 											   allocated(0) {}
+
+ArrayAllocator::~ArrayAllocator() {
+	delete this->allocator;
+}
 
 bool ArrayAllocator::check(const size_t length) {
 	if (heap_size + allocated + length > next_size) {
@@ -34,7 +39,7 @@ bool ArrayAllocator::check(const size_t length) {
 void* ArrayAllocator::Allocate(size_t length) {
 	if (check(length)) {
 		allocated += length;
-		return std::calloc(length, 1);
+		return this->allocator->Allocate(length);
 	} else {
 		return nullptr;
 	}
@@ -43,7 +48,7 @@ void* ArrayAllocator::Allocate(size_t length) {
 void* ArrayAllocator::AllocateUninitialized(size_t length) {
 	if (check(length)) {
 		allocated += length;
-		return std::malloc(length);
+		return this->allocator->AllocateUninitialized(length);
 	} else {
 		return nullptr;
 	}
@@ -52,7 +57,7 @@ void* ArrayAllocator::AllocateUninitialized(size_t length) {
 void ArrayAllocator::Free(void* data, size_t length) {
 	allocated -= length;
 	next_size -= length;
-	std::free(data);
+	return this->allocator->Free(data, length);
 }
 
 void* ArrayAllocator::Reallocate(void *data, size_t old_length, size_t new_length) {
@@ -62,5 +67,5 @@ void* ArrayAllocator::Reallocate(void *data, size_t old_length, size_t new_lengt
 			return nullptr;
 		}
 	}
-	return v8::ArrayBuffer::Allocator::Reallocate(data, old_length, new_length);
+	return this->allocator->Reallocate(data, old_length, new_length);
 }

--- a/plv8_allocator.h
+++ b/plv8_allocator.h
@@ -12,11 +12,13 @@ private:
 	size_t heap_size;
 	size_t next_size;
 	size_t allocated;
+	v8::ArrayBuffer::Allocator* allocator;
 
 	bool check(size_t length);
 
 public:
 	explicit ArrayAllocator(size_t limit);
+	~ArrayAllocator();
 	void* Allocate(size_t length) final;
 	void* AllocateUninitialized(size_t length) final;
 	void Free(void* data, size_t length) final;


### PR DESCRIPTION
I am building plv8 against more recent versions of v8. The most recent has the option of using a sandbox mode. In that mode, it is necessary to use the plv8 default allocator. Since it has no constructor, it is easiest to define the plv8 allocator as a facade. This should also work for earlier v8 versions.
