### PR TITLE
 fixed bug with scalar JSONB arguments wrongly interpreted as array

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -62,7 +62,7 @@ endif
 
 DATA = $(PLV8_DATA)
 DATA_built = plv8.sql
-REGRESS = init-extension plv8 plv8-errors inline json startup_pre startup varparam json_conv \
+REGRESS = init-extension plv8 plv8-errors scalar_args inline json startup_pre startup varparam json_conv \
 		  jsonb_conv window guc es6 arraybuffer composites currentresource startup_perms bytea find_function_perms \
 		  memory_limits reset show array_spread regression procedure
 

--- a/expected/scalar_args.out
+++ b/expected/scalar_args.out
@@ -1,0 +1,59 @@
+CREATE OR REPLACE FUNCTION jsonb_scalar_cat(data jsonb) RETURNS jsonb LANGUAGE plv8 AS
+$$ plv8.elog(NOTICE, 'arg = ' + JSON.stringify(data));  return data; $$;
+SELECT jsonb_scalar_cat(to_jsonb('asd'::TEXT));
+NOTICE:  arg = "asd"
+ jsonb_scalar_cat 
+------------------
+ "asd"
+(1 row)
+
+SELECT jsonb_scalar_cat(to_jsonb(19450509::INT));
+NOTICE:  arg = 19450509
+ jsonb_scalar_cat 
+------------------
+ 19450509
+(1 row)
+
+SELECT jsonb_scalar_cat(to_jsonb(false::BOOL));
+NOTICE:  arg = false
+ jsonb_scalar_cat 
+------------------
+ false
+(1 row)
+
+SELECT jsonb_scalar_cat('{"key":[null, true, false, 19450509, "string"]}'::JSONB);
+NOTICE:  arg = {"key":[null,true,false,19450509,"string"]}
+                 jsonb_scalar_cat                 
+--------------------------------------------------
+ {"key": [null, true, false, 19450509, "string"]}
+(1 row)
+
+SELECT jsonb_scalar_cat('{"key":true}'::JSONB);
+NOTICE:  arg = {"key":true}
+ jsonb_scalar_cat 
+------------------
+ {"key": true}
+(1 row)
+
+SELECT jsonb_scalar_cat('{"key":"true"}'::JSONB);
+NOTICE:  arg = {"key":"true"}
+ jsonb_scalar_cat 
+------------------
+ {"key": "true"}
+(1 row)
+
+SELECT jsonb_scalar_cat('{"key":19450509}'::JSONB);
+NOTICE:  arg = {"key":19450509}
+ jsonb_scalar_cat  
+-------------------
+ {"key": 19450509}
+(1 row)
+
+SELECT jsonb_scalar_cat('{"key":null}'::JSONB);
+NOTICE:  arg = {"key":null}
+ jsonb_scalar_cat 
+------------------
+ {"key": null}
+(1 row)
+
+--SELECT jsonb_scalar_cat('null'::TEXT::JSONB);

--- a/plv8_type.cc
+++ b/plv8_type.cc
@@ -1017,7 +1017,14 @@ ToScalarValue(Datum datum, bool isnull, plv8_type *type)
 	{
 #if JSONB_DIRECT_CONVERSION
 		Jsonb *jsonb = (Jsonb *) PG_DETOAST_DATUM(datum);
-		Local<v8::Value> result = ConvertJsonb(&jsonb->root);
+		Local<v8::Value> result;
+		if (JB_ROOT_IS_SCALAR(jsonb)) {
+			JsonbValue  jb;
+			JsonbExtractScalar(&jsonb->root, &jb);
+			result = GetJsonbValue(&jb);
+		} else {
+			result = ConvertJsonb(&jsonb->root);
+		}
 #else
 		Local<v8::Value>	jsonString = ToString(datum, type);
 		JSONObject JSON;

--- a/plv8_type.cc
+++ b/plv8_type.cc
@@ -538,9 +538,10 @@ ConvertObject(Local<v8::Object> object) {
 	} else if (object->IsObject()) {
 		val = JsonbObjectFromObject(&pstate, object);
 	} else {
-		val = pushJsonbValue(&pstate, WJB_BEGIN_ARRAY, NULL);
-		val = JsonbFromValue(&pstate, object, WJB_ELEM);
+		pushJsonbValue(&pstate, WJB_BEGIN_ARRAY, NULL);
+		JsonbFromValue(&pstate, object, WJB_ELEM);
 		val = pushJsonbValue(&pstate, WJB_END_ARRAY, NULL);
+                val->val.array.rawScalar = true;
 	}
 
 	MemoryContextSwitchTo(oldcontext);

--- a/sql/scalar_args.sql
+++ b/sql/scalar_args.sql
@@ -1,0 +1,21 @@
+CREATE OR REPLACE FUNCTION jsonb_scalar_cat(data jsonb) RETURNS jsonb LANGUAGE plv8 AS
+$$ plv8.elog(NOTICE, 'arg = ' + JSON.stringify(data));  return data; $$;
+
+SELECT jsonb_scalar_cat(to_jsonb('asd'::TEXT));
+
+SELECT jsonb_scalar_cat(to_jsonb(19450509::INT));
+
+SELECT jsonb_scalar_cat(to_jsonb(false::BOOL));
+
+SELECT jsonb_scalar_cat('{"key":[null, true, false, 19450509, "string"]}'::JSONB);
+
+SELECT jsonb_scalar_cat('{"key":true}'::JSONB);
+
+SELECT jsonb_scalar_cat('{"key":"true"}'::JSONB);
+
+SELECT jsonb_scalar_cat('{"key":19450509}'::JSONB);
+
+SELECT jsonb_scalar_cat('{"key":null}'::JSONB);
+
+
+--SELECT jsonb_scalar_cat('null'::TEXT::JSONB);


### PR DESCRIPTION
Hi, we are switching from plv8 2.x to 3.x and have found a bug caused by JSONB_DIRECT_CONVERSION.

How to reproduce:

```
mi=> CREATE OR REPLACE FUNCTION jsonb_cat(data jsonb) RETURNS jsonb LANGUAGE plv8 AS
$$  return data; $$;

mi=> SELECT jsonb_cat(to_jsonb('"asd"'::TEXT));
 jsonb_cat
-----------
 ["asd"]
(1 row)

mi=> SELECT jsonb_cat(to_jsonb(1::INT));
 jsonb_cat
-----------
 [1]
(1 row)

mi=> SELECT jsonb_cat(to_jsonb(false::BOOL));
 jsonb_cat
-----------
 [false]
(1 row)
```

We expect scalar JSON value returned, not array. Obvious fix is provided. Thanks for plv8, it is a joy!
