### PR TITLE
Bytea parameter crashes plv8 with out of memory error

### DIFF
--- a/plv8_allocator.h
+++ b/plv8_allocator.h
@@ -10,8 +10,8 @@ class ArrayAllocator : public v8::ArrayBuffer::Allocator {
 private:
 	size_t heap_limit;
 	size_t heap_size;
-	size_t next_size;
-	size_t allocated;
+	std::atomic<size_t> next_size;
+	std::atomic<size_t> allocated;
 	v8::ArrayBuffer::Allocator* allocator;
 
 	bool check(size_t length);


### PR DESCRIPTION
We're using plv8 for operations on binary data represented as `bytea` columns in Postgres. We've started seeing plv8 crashing Postgres with the error message `Out of memory error` (likely coming from [here](https://github.com/plv8/plv8/blob/f23425b5115203d7b339123d5088bf82bfff51cc/plv8.cc#L213)). In the Postgres logs, we see the following:

```
<--- Last few GCs --->
[29773:0x3fa7de0]    55701 ms: Mark-sweep (reduce) 0.8 (2.7) -> 0.8 (1.9) MB, 1.6 / 0.1 ms  (average mu = 0.011, current mu = 0.009) external memory pressure GC in old space requested
[29773:0x3fa7de0]    55702 ms: Mark-sweep (reduce) 0.8 (1.9) -> 0.8 (1.9) MB, 1.0 / 0.1 ms  (average mu = 0.011, current mu = 0.011) external memory pressure GC in old space requested
<--- JS stacktrace --->
```

We've managed to narrow it down to being associated with `bytea` parameters. Below is the smallest repro we've been able to construct that somewhat mirrors our use case:

```sql
create or replace function noop(data bytea) returns void as $$
$$ language plv8;

do $$
  for(let i = 0; i < 2000; i++) {
    plv8.execute(`
      select noop(repeat('0', 1024*1024)::bytea) from generate_series(0, 100)
    `);
  }
$$ language plv8;
```
The test passes a 1MB `bytea` value to a dummy plv8 function for 100 rows, and then repeats the process up to 2,000 times. 
You can see this test case failing as part of the Github Actions workflow [here](https://github.com/andreas/plv8/actions/runs/6754701490/job/18362450361).

In practice, we process on the order of ~500 rows totalling ~16MB of bytea values for a single query. Over the course of a few minutes, queries of that shape might run many times over, which ultimately leads to the crash.

The repro can be simplified to the following, but departs further from our actual use case:

```sql
select count(noop(repeat('0', 1024*1024)::bytea)) from generate_series(0, 200*1000);
```