### PR TITLE
Fix code blocks in BUILTINS.md

### DIFF
--- a/docs/BUILTINS.md
+++ b/docs/BUILTINS.md
@@ -47,9 +47,9 @@ CREATE FUNCTION caller(a int, t int) RETURNS int AS $$
 $$ LANGUAGE plv8;
 ```
 
-With `plv8.find_function()``, you can look up other PLV8 functions. If they
+With `plv8.find_function()`, you can look up other PLV8 functions. If they
 are not a PLV8 function, and error is thrown. The function signature parameter
-to `plv8.find_function()`` is either of `regproc` (function name only) or
+to `plv8.find_function()` is either of `regproc` (function name only) or
 `regprocedure` (function name with argument types). You can make use of the
 internal type for arguments and void type for return type for the pure Javascript
 function to make sure any invocation from SQL statements should not occur.


### PR DESCRIPTION
There were additional backticks in the documentation for `find_function` which led to incorrect formatting:

![Screenshot 2023-11-08 at 11 12 28 AM](https://github.com/plv8/plv8/assets/691365/52b9a6ae-5f74-4c3c-b46f-5599f188ff2b)

This change removes the extraneous backticks, fixing the formatting.  