### PR TITLE
Add workflow to release on PGXN for a semver tag

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,4 @@
+.gitattributes export-ignore
+.github export-ignore
+.gitignore export-ignore
+.gitmodules export-ignore

--- a/.github/workflows/pgxn-release.yml
+++ b/.github/workflows/pgxn-release.yml
@@ -1,0 +1,21 @@
+name: 🚀 Release on PGXN
+on:
+  push:
+    # Release on semantic version tag.
+    tags: ['v[0-9]+.[0-9]+.[0-9]+']
+jobs:
+  release:
+    name: Release on PGXN
+    runs-on: ubuntu-latest
+    container: pgxn/pgxn-tools
+    steps:
+    - name: Check out the repo
+      uses: actions/checkout@v4
+    - name: Bundle the Release
+      env: { GIT_ARCHIVE_CMD: archive-all }
+      run: pgxn-bundle
+    - name: Release on PGXN
+      env:
+        PGXN_USERNAME: ${{ secrets.PGXN_USERNAME }}
+        PGXN_PASSWORD: ${{ secrets.PGXN_PASSWORD }}
+      run: pgxn-release

--- a/META.json
+++ b/META.json
@@ -28,6 +28,9 @@
             "abstract": "A procedural language in JavaScript"
         }
     },
+    "no_index": {
+        "directory": [ "deps" ]
+    },
     "resources": {
         "homepage": "https://plv8.github.io/",
         "bugtracker": {

--- a/Makefile
+++ b/Makefile
@@ -41,8 +41,10 @@ all: v8 $(OBJS)
 # For some reason, this solves parallel make dependency.
 plv8_config.h plv8.so: v8
 
-deps/v8-cmake/build/libv8_libbase.a:
+deps/v8-cmake/README.md:
 	@git submodule update --init --recursive
+
+deps/v8-cmake/build/libv8_libbase.a: deps/v8-cmake/README.md
 	@cd deps/v8-cmake && mkdir -p build && cd build && cmake -Denable-fPIC=ON -DCMAKE_BUILD_TYPE=Release ../ && make -j $(NUMPROC)
 
 v8: deps/v8-cmake/build/libv8_libbase.a


### PR DESCRIPTION
Just set `PGXN_USERNAME` and `PGXN_PASSWORD` in the project secrets and it should just do it on the next semver tag.

Also use the `GIT_ARCHIVE_CMD` variable so that the bundle includes all submodules, teach PGXN not to index them, and tweak the `Makefile` to avoid calling `git` if the submodule is already included. Fixes #569.

Check out [this build](https://github.com/theory/plv8/actions/runs/7646998561/job/20836995424) to see it in action (without actually publishing to PGXN). The "Bundle Release" step shows it including the submodule, and the "Release on PGXN" step runs `ls -lah plv8-*.zip` to show the final bundle at 47MB.