### PR TITLE
Removing No ops macros.

### DIFF
--- a/plv8.cc
+++ b/plv8.cc
@@ -1073,9 +1073,6 @@ CallSRFunction(PG_FUNCTION_ARGS, plv8_exec_env *xenv,
 		conv.ToDatum(result, tupstore);
 	}
 
-	/* clean up and return the tuplestore */
-	tuplestore_donestoring(tupstore);
-
 	return (Datum) 0;
 }
 

--- a/plv8_func.cc
+++ b/plv8_func.cc
@@ -618,7 +618,6 @@ plv8_Execute(const FunctionCallbackInfo<v8::Value> &args)
 	PG_CATCH();
 	{
 		subtran.exit(false);
-		SPI_pop_conditional(true);
 		throw pg_error();
 	}
 	PG_END_TRY();


### PR DESCRIPTION
These macros have now been removed in Postgres community version. These macros have been no-ops for a while.
The commit link: https://github.com/postgres/postgres/commit/75680c3d805e2323cd437ac567f0677fdfc7b680


