### PR TITLE
Remove obsolete macros

### DIFF
--- a/plv8.cc
+++ b/plv8.cc
@@ -1073,9 +1073,6 @@ CallSRFunction(PG_FUNCTION_ARGS, plv8_exec_env *xenv,
 		conv.ToDatum(result, tupstore);
 	}
 
-	/* clean up and return the tuplestore */
-	tuplestore_donestoring(tupstore);
-
 	return (Datum) 0;
 }
 

--- a/plv8_func.cc
+++ b/plv8_func.cc
@@ -618,7 +618,6 @@ plv8_Execute(const FunctionCallbackInfo<v8::Value> &args)
 	PG_CATCH();
 	{
 		subtran.exit(false);
-		SPI_pop_conditional(true);
 		throw pg_error();
 	}
 	PG_END_TRY();


### PR DESCRIPTION
There are some macros in Postgresql were no-op for 20 years and eventually removed:

commit 75680c3d805e2323cd437ac567f0677fdfc7b680
Author: Nathan Bossart <nathan@postgresql.org>
Date:   Mon Nov 27 13:10:09 2023 -0600

    Retire a few backwards compatibility macros.

    As of commits dd04e958c8 and 1833f1a1c3, tuplestore_donestoring(),
    SPI_push(), SPI_pop(), SPI_push_conditional(),
    SPI_pop_conditional(), and SPI_restore_connection() are no-op
    macros provided for backwards compatibility.  This commit removes
    these macros, so any uses in third-party code will need to be
    removed, too.  Since these macros have been no-ops for a while,
    such adjustments won't produce any behavior changes for all
    currently-supported versions of PostgreSQL.