### PR TITLE
Fix version specification typo in docs/README.md

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -4,7 +4,7 @@ PLV8 is a _trusted_ Javascript language extension for PostgreSQL. It can be
 used for _stored procedures_, _triggers_, etc.
 
 PLV8 works with most versions of Postgres, but works best with `13` and above,
-including `14`, `16`, and `16`.
+including `14`, `15`, and `16`.
 
 ## Installing PLV8
 


### PR DESCRIPTION
I'm planning to add some JS procedures to our production server (which is on PostgreSQL 15.8), but I'm a bit worried after seeing this line during initial investigation.

After trying to build and install plv8, it seems to be working well:

```log
root@db-test:/plv8# make installcheck
echo "+++ regress install-check in  +++" && /usr/lib/postgresql/15/lib/pgxs/src/makefiles/../../src/test/regress/pg_regress --inputdir=./ --bindir='/usr/lib/postgresql/15/bin'    --dbname=contrib_regression init-extension plv8 plv8-errors scalar_args inline json startup_pre startup varparam json_conv jsonb_conv window guc es6 arraybuffer composites currentresource startup_perms bytea find_function_perms memory_limits reset show array_spread regression procedure bigint
+++ regress install-check in  +++
(using postmaster on Unix socket, default port)
============== dropping database "contrib_regression" ==============
SET
DROP DATABASE
============== creating database "contrib_regression" ==============
CREATE DATABASE
ALTER DATABASE
ALTER DATABASE
ALTER DATABASE
ALTER DATABASE
ALTER DATABASE
ALTER DATABASE
============== running regression test queries        ==============
test init-extension               ... ok           51 ms
test plv8                         ... ok          211 ms
test plv8-errors                  ... ok           91 ms
test scalar_args                  ... ok           72 ms
test inline                       ... ok           63 ms
test json                         ... ok           72 ms
test startup_pre                  ... ok           82 ms
test startup                      ... ok          113 ms
test varparam                     ... ok           57 ms
test json_conv                    ... ok           67 ms
test jsonb_conv                   ... ok           67 ms
test window                       ... ok           88 ms
test guc                          ... ok           60 ms
test es6                          ... ok           74 ms
test arraybuffer                  ... ok           64 ms
test composites                   ... ok           63 ms
test currentresource              ... ok           54 ms
test startup_perms                ... ok           68 ms
test bytea                        ... ok           59 ms
test find_function_perms          ... ok           66 ms
test memory_limits                ... ok         1025 ms
test reset                        ... ok           54 ms
test show                         ... ok           60 ms
test array_spread                 ... ok         4300 ms
test regression                   ... ok           51 ms
test procedure                    ... ok           57 ms
test bigint                       ... ok           76 ms

======================
 All 27 tests passed.
======================
```

All built-in tests pass, and a few simple procedures worked well without any immediately noticeable issues:

```
root@db-test:/plv8# psql
psql (15.8 (Debian 15.8-1.pgdg110+1))
Type "help" for help.

root=# CREATE EXTENSION plv8;
CREATE EXTENSION
root=# SELECT plv8_version();
 plv8_version
--------------
 3.2.2
(1 row)

root=# CREATE FUNCTION plv8_test(keys TEXT[], vals TEXT[]) RETURNS JSON AS $$
root$#     var o = {};
root$#     for(var i=0; i<keys.length; i++){
root$#         o[keys[i]] = vals[i];
root$#     }
root$#     return o;
root$# $$ LANGUAGE plv8 IMMUTABLE STRICT;
CREATE FUNCTION
root=# SELECT plv8_test(ARRAY['name', 'age'], ARRAY['Tom', '29']);
         plv8_test
---------------------------
 {"name":"Tom","age":"29"}
(1 row)

root=#
```

So it appears to be a typo in the README.md :)
