### PR TITLE
Upgrade to cpp20 for v8 11.6 support

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,9 +4,9 @@ PLV8_VERSION = 3.2.3
 CP := cp
 PG_CONFIG = pg_config
 PGXS := $(shell $(PG_CONFIG) --pgxs)
-SHLIB_LINK += -std=c++17
+SHLIB_LINK += -std=c++20
 PG_CPPFLAGS := -fPIC -Wall -Wno-register -xc++
-PG_LDFLAGS := -std=c++17
+PG_LDFLAGS := -std=c++20
 
 SRCS = plv8.cc plv8_type.cc plv8_func.cc plv8_param.cc plv8_allocator.cc plv8_guc.cc
 OBJS = $(SRCS:.cc=.o)
@@ -21,11 +21,11 @@ else
 	UNAME_S := $(shell uname -s)
 	ifeq ($(UNAME_S),Darwin)
 		CCFLAGS += -stdlib=libc++
-		SHLIB_LINK += -stdlib=libc++ -std=c++17 -lc++
+		SHLIB_LINK += -stdlib=libc++ -std=c++20 -lc++
 		NUMPROC := $(shell sysctl hw.ncpu | awk '{print $$2}')
 	endif
 	ifeq ($(UNAME_S),Linux)
-		SHLIB_LINK += -lrt -std=c++17
+		SHLIB_LINK += -lrt -std=c++20
 		NUMPROC := $(shell grep -c ^processor /proc/cpuinfo)
 	endif
 endif
@@ -52,7 +52,7 @@ v8: deps/v8-cmake/build/libv8_libbase.a
 # enable direct jsonb conversion by default
 CCFLAGS += -DJSONB_DIRECT_CONVERSION
 
-CCFLAGS += -Ideps/v8-cmake/v8/include -std=c++17
+CCFLAGS += -Ideps/v8-cmake/v8/include -std=c++20
 
 ifdef EXECUTION_TIMEOUT
 	CCFLAGS += -DEXECUTION_TIMEOUT
@@ -74,9 +74,9 @@ else
 	REGRESS += bigint_graceful
 endif
 
-SHLIB_LINK += -lv8_base_without_compiler -lv8_compiler -lv8_snapshot -lv8_inspector -lv8_libplatform -lv8_base_without_compiler -lv8_libsampler -lv8_torque_generated -lv8_libbase
+SHLIB_LINK += -lv8_initializers -lv8_base_without_compiler -lv8_compiler -lv8_snapshot -lv8_inspector -lv8_libplatform -lv8_base_without_compiler -lv8_libsampler -lv8_torque_generated -lv8_libbase
 
-OPTFLAGS = -std=c++17 -fno-rtti -O2
+OPTFLAGS = -std=c++20 -fno-rtti -O2
 CCFLAGS += -Wall $(OPTFLAGS)
 
 generate_upgrades:


### PR DESCRIPTION
v8-cmake was upgraded to cpp20. cpp20 is needed to build v8 11.6 with v8-cmake

Tested with PostgreSQL 17 on Debian and Aplpine.