### PR TITLE
Fix possible overflow in Window Functions

### DIFF
--- a/plv8_func.cc
+++ b/plv8_func.cc
@@ -1295,7 +1295,7 @@ plv8_WinGetPartitionLocal(const FunctionCallbackInfo<v8::Value>& args)
 	else {
 		const int input_size = args[0]->Int32Value(isolate->GetCurrentContext()).ToChecked();
 		if (input_size < 0) {
-			args.GetReturnValue().Set(isolate->ThrowException(String::NewFromUtf8(args.GetIsolate(), "allocation size cannot be negative").ToLocalChecked()));
+			args.GetReturnValue().Set(isolate->ThrowException(v8::String::NewFromUtf8(args.GetIsolate(), "allocation size cannot be negative").ToLocalChecked()));
 			return;
 	    	}
 		size = input_size;

--- a/plv8_func.cc
+++ b/plv8_func.cc
@@ -1292,9 +1292,14 @@ plv8_WinGetPartitionLocal(const FunctionCallbackInfo<v8::Value>& args)
 
 	if (args.Length() < 1)
 		size = 1000; /* default 1K */
-	else
-		size = args[0]->Int32Value(isolate->GetCurrentContext()).ToChecked();
-
+	else {
+		const int input_size = args[0]->Int32Value(isolate->GetCurrentContext()).ToChecked();
+		if (input_size < 0) {
+			args.GetReturnValue().Set(isolate->ThrowException(String::NewFromUtf8(args.GetIsolate(), "allocation size cannot be negative").ToLocalChecked()));
+			return;
+	    	}
+		size = input_size;
+	}
 	size += sizeof(size_t) * 2;
 
 	PG_TRY();


### PR DESCRIPTION
The issue is that the variable `size` is of the type `size_t`, which is an unsigned integer. 

Passing a negative value leads to an integer overflow, and the requested size is in the order of 2^64 bytes, which is over 10^10 GB, leading to a heap overflow. 

Calling the window function will now lead to an error (ERROR:  allocation size cannot be negative) instead of crashing.