### PR TITLE
Match plv8 external array types by their element type, in addition to their name.

### DIFF
--- a/plv8_type.cc
+++ b/plv8_type.cc
@@ -1061,12 +1061,17 @@ ToArrayValue(Datum datum, bool isnull, plv8_type *type)
 		 */
 		if (!ARR_HASNULL(array) && ARR_NDIM(array) <= 1)
 		{
-			int			data_bytes = ARR_SIZE(array) -
+			if (ARR_ELEMTYPE(array)==INT2OID || ARR_ELEMTYPE(array)==INT4OID ||
+          		   ARR_ELEMTYPE(array)==INT8OID || ARR_ELEMTYPE(array)==FLOAT4OID ||
+          		   ARR_ELEMTYPE(array)==FLOAT8OID) 
+			{
+				int			data_bytes = ARR_SIZE(array) -
 										ARR_OVERHEAD_NONULLS(1);
-			return CreateExternalArray(ARR_DATA_PTR(array),
+				return CreateExternalArray(ARR_DATA_PTR(array),
 									   type->ext_array,
 									   data_bytes,
 									   PointerGetDatum(array));
+			}
 		}
 
 		throw js_error("NULL element, or multi-dimension array not allowed"


### PR DESCRIPTION
The issue is that plv8_fill_type() matches types only by their names but not their shapes or element types.

This PR fixes that by checking the element type and only allowing predefined types (int2, int4, int8, float4, float8) for v8's typed arrays.