### PR TITLE
Add Plv8 support for pg19: add missing hsearch.h include and adapt to…

### DIFF
--- a/plv8.cc
+++ b/plv8.cc
@@ -33,6 +33,7 @@ extern "C" {
 #include "utils/lsyscache.h"
 #include "utils/rel.h"
 #include "utils/syscache.h"
+#include "utils/hsearch.h"
 
 #include <signal.h>
 

--- a/plv8_type.cc
+++ b/plv8_type.cc
@@ -270,10 +270,10 @@ ConvertJsonb(JsonbContainer *in) {
 	return JsonbIterate(&it, container);
 }
 
-static JsonbValue *
-JsonbObjectFromObject(JsonbParseState **pstate, Local<v8::Object> object);
-static JsonbValue *
-JsonbArrayFromArray(JsonbParseState **pstate, Local<v8::Object> object);
+static void
+JsonbObjectFromObject(JsonbInState *pstate, Local<v8::Object> object);
+static void
+JsonbArrayFromArray(JsonbInState *pstate, Local<v8::Object> object);
 
 static void LogType(Local<v8::Value> val, bool asError = true) {
 	if( val->IsUndefined() )
@@ -386,8 +386,8 @@ TimeAs8601 (double millis) {
 	return buf;
 }
 
-static JsonbValue *
-JsonbFromValue(JsonbParseState **pstate, Local<v8::Value> value, JsonbIteratorToken type) {
+static void
+JsonbFromValue(JsonbInState *pstate, Local<v8::Value> value, JsonbIteratorToken type) {
 	Isolate *isolate = Isolate::GetCurrent();
 	Local<Context>		context = isolate->GetCurrentContext();
 	JsonbValue val;
@@ -405,7 +405,7 @@ JsonbFromValue(JsonbParseState **pstate, Local<v8::Value> value, JsonbIteratorTo
 		} else if (value->IsNull()) {
 			val.type = jbvNull;
 		} else if (value->IsUndefined()) {
-			return NULL;
+			return;
 		} else if (value->IsString()) {
 			val.type = jbvString;
 			v8::String::Utf8Value utf8(isolate, value->ToString(context).ToLocalChecked());
@@ -444,56 +444,53 @@ JsonbFromValue(JsonbParseState **pstate, Local<v8::Value> value, JsonbIteratorTo
 		}
 	}
 
-	return pushJsonbValue(pstate, type, &val);
+	pushJsonbValue(pstate, type, &val);
 }
 
-static JsonbValue *
-JsonbArrayFromArray(JsonbParseState **pstate, Local<v8::Object> object) {
+static void
+JsonbArrayFromArray(JsonbInState *pstate, Local<v8::Object> object) {
 	Isolate *isolate = Isolate::GetCurrent();
 	Local<Context>		context = isolate->GetCurrentContext();
-	JsonbValue *val = pushJsonbValue(pstate, WJB_BEGIN_ARRAY, NULL);
+	pushJsonbValue(pstate, WJB_BEGIN_ARRAY, NULL);
 	Local<v8::Array> a = Local<v8::Array>::Cast(object);
 	for (size_t i = 0; i < a->Length(); i++) {
 		Local<v8::Value> o = a->Get(context, i).ToLocalChecked();
 
 		if (o->IsArray()) {
-			val = JsonbArrayFromArray(pstate, Local<v8::Array>::Cast(o));
+			JsonbArrayFromArray(pstate, Local<v8::Array>::Cast(o));
 		} else if (o->IsObject()) {
-			val = JsonbObjectFromObject(pstate, Local<v8::Object>::Cast(o));
+			JsonbObjectFromObject(pstate, Local<v8::Object>::Cast(o));
 		} else {
-			val = JsonbFromValue(pstate, o, WJB_ELEM);
+			JsonbFromValue(pstate, o, WJB_ELEM);
 		}
 	}
 
-	val = pushJsonbValue(pstate, WJB_END_ARRAY, NULL);
-
-	return val;
+	pushJsonbValue(pstate, WJB_END_ARRAY, NULL);
 }
 
-static JsonbValue *
-JsonbObjectFromObject(JsonbParseState **pstate, Local<v8::Object> object) {
+static void
+JsonbObjectFromObject(JsonbInState *pstate, Local<v8::Object> object) {
 	Isolate *isolate = Isolate::GetCurrent();
 	Local<Context>		context = isolate->GetCurrentContext();
-	JsonbValue *val = pushJsonbValue(pstate, WJB_BEGIN_OBJECT, NULL);
+	pushJsonbValue(pstate, WJB_BEGIN_OBJECT, NULL);
 	Local<Array> arr = object->GetOwnPropertyNames(context).ToLocalChecked();
 
 	for (size_t i = 0; i < arr->Length(); i++) {
 		Local<v8::Value> v = arr->Get(context, i).ToLocalChecked();
-		val = JsonbFromValue(pstate, v, WJB_KEY);
+		JsonbFromValue(pstate, v, WJB_KEY);
 		Local<v8::Value> o = object->Get(context, v).ToLocalChecked();
 
 		if (o->IsDate()) {
-			val = JsonbFromValue(pstate, o, WJB_VALUE);
+			JsonbFromValue(pstate, o, WJB_VALUE);
 		} else if (o->IsArray()) {
-			val = JsonbArrayFromArray(pstate, Local<v8::Array>::Cast(o));
+			JsonbArrayFromArray(pstate, Local<v8::Array>::Cast(o));
 		} else if (o->IsObject()) {
-			val = JsonbObjectFromObject(pstate, Local<v8::Object>::Cast(o));
+			JsonbObjectFromObject(pstate, Local<v8::Object>::Cast(o));
 		} else {
-			val = JsonbFromValue(pstate, o, WJB_VALUE);
+			JsonbFromValue(pstate, o, WJB_VALUE);
 		}
 	}
-	val = pushJsonbValue(pstate, WJB_END_OBJECT, NULL);
-	return val;
+	pushJsonbValue(pstate, WJB_END_OBJECT, NULL);
 }
 
 static Jsonb *
@@ -508,19 +505,21 @@ ConvertObject(Local<v8::Object> object) {
 
 	MemoryContextSwitchTo(conversion_context);
 
-  JsonbParseState *pstate = NULL;
+  JsonbInState pstate = {0};
   JsonbValue *val;
 
 	if (object->IsArray()) {
-		val = JsonbArrayFromArray(&pstate, object);
+		JsonbArrayFromArray(&pstate, object);
 	} else if (object->IsObject()) {
-		val = JsonbObjectFromObject(&pstate, object);
+		JsonbObjectFromObject(&pstate, object);
 	} else {
 		pushJsonbValue(&pstate, WJB_BEGIN_ARRAY, NULL);
 		JsonbFromValue(&pstate, object, WJB_ELEM);
-		val = pushJsonbValue(&pstate, WJB_END_ARRAY, NULL);
-                val->val.array.rawScalar = true;
+		pushJsonbValue(&pstate, WJB_END_ARRAY, NULL);
+                pstate.result->val.array.rawScalar = true;
 	}
+
+	val = pstate.result;
 
 	MemoryContextSwitchTo(oldcontext);
 


### PR DESCRIPTION
In PG19, utils/hsearch.h is no longer transitively included, causing
undeclared HASHCTL/hash_create/hash_search symbols in plv8.cc.

Also, pushJsonbValue changed signature from
  JsonbValue* pushJsonbValue(JsonbParseState**, ...)
to
  void pushJsonbValue(JsonbInState*, ...)

Updated plv8_type.cc to use JsonbInState and retrieve results via
pstate.result instead of the return value

related to https://github.com/plv8/plv8/issues/608