### PR TITLE
Use PG_MODULE_MAGIC_EXT in PostgreSQL 18 and later

### DIFF
--- a/plv8.cc
+++ b/plv8.cc
@@ -44,7 +44,14 @@ extern "C" {
 #endif
 #endif
 
+#if PG_VERSION_NUM >= 180000
+PG_MODULE_MAGIC_EXT(
+	.name = "plv8",
+	.version = PLV8_VERSION
+);
+#else
 PG_MODULE_MAGIC;
+#endif
 
 PGDLLEXPORT Datum	plv8_call_handler(PG_FUNCTION_ARGS);
 PGDLLEXPORT Datum	plv8_call_validator(PG_FUNCTION_ARGS);


### PR DESCRIPTION
The `PG_MODULE_MAGIC_EXT` macro was added in PostgreSQL 18 and makes it possible to see which version of the library is actually loaded using `pg_get_loaded_modules()`.